### PR TITLE
[fix] Change `usort` callback function so it returns integer values instead of bool - compatibility with PHP8

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -326,10 +326,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function sort_array( $a, $b ) {
 			if ( ! isset( $a['section_order'] ) ) {
-				return false;
+				return 0;
 			}
 
-			return $a['section_order'] > $b['section_order'];
+			return $a['section_order'] > $b['section_order'] ? 1 : -1;
 		}
 
 		/**


### PR DESCRIPTION
PHP* is throwing this error: 

PHP Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

WordPress-Settings-Framework-master/wp-settings-framework.php:293
usort()
WordPress-Settings-Framework-master/wp-settings-framework.php:293
WordPressSettingsFramework->process_settings()
WordPress-Settings-Framework-master/wp-settings-framework.php:156
WordPressSettingsFramework->admin_init()
wp-includes/class-wp-hook.php:292
do_action('admin_init')
wp-admin/admin.php:175

closes #47 