### PR TITLE
[new] Show and hide tabs and controls with control groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -298,13 +298,36 @@
 			$( '.control-group__hide-if' ).closest( 'tr' ).show();
 			$( '.tab-control-group__hide-if' ).closest( 'li' ).show();
 
+			var section_control_show = $( '.section-control-group__show-if' );
+			var section_control_hide = $( '.section-control-group__hide-if' );
+			
+			if ( section_control_show ) {
+				section_control_show.prev().hide();
+				section_control_show.next().hide();
+				if ( section_control_show.next().hasClass( 'wpsf-section-description' ) ) {
+					section_control_show.next().next().hide();
+				}
+			}
+
+			if ( section_control_hide ) {
+				section_control_hide.prev().show();
+				section_control_hide.next().show();
+				if ( section_control_hide.next().hasClass( 'wpsf-section-description' ) ) {
+					section_control_hide.next().next().show();
+				}
+			}
+
 			// Loop and show if the value is set.
 			$( '*[class*="control-group__show-if--"]' ).each( function() {
 				wpsf.show_hide( this, true );
 			});
 
 			$( '*[class*="tab-control-group__show-if--"]' ).each( function() {
-				wpsf.show_hide( this, true, true );
+				wpsf.show_hide( this, true, 'tab' );
+			});
+
+			$( '*[class*="section-control-group__show-if--"]' ).each( function() {
+				wpsf.show_hide( this, true, 'section' );
 			});
 
 			// Loop and hide if the value is set.
@@ -313,18 +336,22 @@
 			});
 
 			$( '*[class*="tab-control-group__hide-if--"]' ).each( function() {
-				wpsf.show_hide( this, false, true );
+				wpsf.show_hide( this, false, 'tab' );
 			});
 
-			$( document.body ).on( 'change', '.control-group__controller, .tab-control-group__controller', wpsf.control_groups );
+			$( '*[class*="section-control-group__hide-if--"]' ).each( function() {
+				wpsf.show_hide( this, false, 'section' );
+			});
+
+			$( document.body ).on( 'change', '.control-group__controller, .tab-control-group__controller, .section-control-group__controller', wpsf.control_groups );
 		},
 
 		/**
 		 * Show or hide control.
 		 */
-		show_hide: function( control, isShow, isTab ) {
-			var prefix = isTab ? 'tab-' : '';
-			var parent = isTab ? 'li' : 'tr';
+		show_hide: function( control, isShow, type ) {
+			var prefix = type ? type + '-' : '';
+			var parent = 'tab' === type ? 'li' : 'tr';
 			var showHide = isShow ? 'show' : 'hide';
 
 			var classes = control.className.split( /\s+/ );
@@ -338,18 +365,29 @@
 				return item.replace( prefix + 'control-group__' + showHide + '-if--', '' );
 			});
 
-			var controllerValue = wpsf.get_controller_value( $( '.' + prefix + 'control-group__controller.' + controller ), controller, isTab );
-			console.log( '.' + prefix + 'control-group__controller.' + controller );
-			console.log( controllerValue );
-			console.log( values );
+			var controllerValue = wpsf.get_controller_value( $( '.' + prefix + 'control-group__controller.' + controller ), controller, type );
+			
 			if ( values.includes( controllerValue ) ) {
-				console.log( 'action' );
-				if ( isShow ) {
-					console.log( 'action show' );
-					$( control ).closest( parent ).show();
+				if ( 'section' === type ) {
+					if ( isShow ) {
+						$( control ).prev().show();
+						$( control ).next().show();
+						if ( $( control ).next().hasClass( 'wpsf-section-description' ) ) {
+							$( control ).next().next().show();
+						}
+					} else {
+						$( control ).prev().hide();
+						$( control ).next().hide();
+						if ( $( control ).next().hasClass( 'wpsf-section-description' ) ) {
+							$( control ).next().next().hide();
+						}
+					}
 				} else {
-					$( control ).closest( parent ).hide();
-					console.log( 'action hide' );
+					if ( isShow ) {
+						$( control ).closest( parent ).show();
+					} else {
+						$( control ).closest( parent ).hide();
+					}
 				}
 			}
 		},
@@ -357,8 +395,8 @@
 		/** 
 		 * Return the control value.
 		 */
-		get_controller_value: function( controllerControl, controllerId, isTab ) {
-			var prefix = isTab ? 'tab-' : '';
+		get_controller_value: function( controllerControl, controllerId, type ) {
+			var prefix = type ? type + '-' : '';
 
 			if ( 'checkbox' === controllerControl.attr( 'type' ) || 'radio' === controllerControl.attr( 'type' ) ) {
 				controllerControl = $( '.' + prefix + 'control-group__controller.' + controllerId + ':checked' );

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -291,11 +291,11 @@
 		 */
 		control_groups: function() {
 			// Hide all controls that only show if a certain value is set.
-			$( '.control-group__show-if' ).closest( 'tr' ).hide();
+			$( '.field-control-group__show-if' ).closest( 'tr' ).hide();
 			$( '.tab-control-group__show-if' ).closest( 'li' ).hide();
 
 			// Show all controls that only hide if a certain value is set.
-			$( '.control-group__hide-if' ).closest( 'tr' ).show();
+			$( '.field-control-group__hide-if' ).closest( 'tr' ).show();
 			$( '.tab-control-group__hide-if' ).closest( 'li' ).show();
 
 			var section_control_show = $( '.section-control-group__show-if' );
@@ -318,8 +318,8 @@
 			}
 
 			// Loop and show if the value is set.
-			$( '*[class*="control-group__show-if--"]' ).each( function() {
-				wpsf.show_hide( this, true );
+			$( '*[class*="field-control-group__show-if--"]' ).each( function() {
+				wpsf.show_hide( this, true, 'field' );
 			});
 
 			$( '*[class*="tab-control-group__show-if--"]' ).each( function() {
@@ -331,8 +331,8 @@
 			});
 
 			// Loop and hide if the value is set.
-			$( '*[class*="control-group__hide-if--"]' ).each( function() {
-				wpsf.show_hide( this, false );
+			$( '*[class*="field-control-group__hide-if--"]' ).each( function() {
+				wpsf.show_hide( this, false, 'field' );
 			});
 
 			$( '*[class*="tab-control-group__hide-if--"]' ).each( function() {
@@ -343,14 +343,14 @@
 				wpsf.show_hide( this, false, 'section' );
 			});
 
-			$( document.body ).on( 'change', '.control-group__controller, .tab-control-group__controller, .section-control-group__controller', wpsf.control_groups );
+			$( document.body ).on( 'change', '.field-control-group__controller, .tab-control-group__controller, .section-control-group__controller', wpsf.control_groups );
 		},
 
 		/**
 		 * Show or hide control.
 		 */
 		show_hide: function( control, isShow, type ) {
-			var prefix = type ? type + '-' : '';
+			var prefix = type + '-';
 			var parent = 'tab' === type ? 'li' : 'tr';
 			var showHide = isShow ? 'show' : 'hide';
 
@@ -396,7 +396,7 @@
 		 * Return the control value.
 		 */
 		get_controller_value: function( controllerControl, controllerId, type ) {
-			var prefix = type ? type + '-' : '';
+			var prefix = type + '-';
 
 			if ( 'checkbox' === controllerControl.attr( 'type' ) || 'radio' === controllerControl.attr( 'type' ) ) {
 				controllerControl = $( '.' + prefix + 'control-group__controller.' + controllerId + ':checked' );

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -19,6 +19,8 @@
 			wpsf.tabs.watch();
 			wpsf.watch_submit();
 			wpsf.control_groups();
+
+			$( document.body ).on( 'change', 'input, select, textarea', wpsf.control_groups );
 		},
 
 		/**
@@ -290,125 +292,124 @@
 		 * Dynamic control groups.
 		 */
 		control_groups: function() {
-			// Hide all controls that only show if a certain value is set.
-			$( '.field-control-group__show-if' ).closest( 'tr' ).hide();
-			$( '.tab-control-group__show-if' ).closest( 'li' ).hide();
+			// If show if, hide by default.
+			$( '.show-if' ).each( function( index ) {
+				var element = $( this );
+				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
+				
+				// Field.
+				if ( 'td' === parent_tag ) {
+					element.closest( 'tr' ).hide();
 
-			// Show all controls that only hide if a certain value is set.
-			$( '.field-control-group__hide-if' ).closest( 'tr' ).show();
-			$( '.tab-control-group__hide-if' ).closest( 'li' ).show();
-
-			var section_control_show = $( '.section-control-group__show-if' );
-			var section_control_hide = $( '.section-control-group__hide-if' );
-			
-			if ( section_control_show ) {
-				section_control_show.prev().hide();
-				section_control_show.next().hide();
-				if ( section_control_show.next().hasClass( 'wpsf-section-description' ) ) {
-					section_control_show.next().next().hide();
+					wpsf.maybe_show_element( element, function() {
+						element.closest( 'tr' ).show();
+					} );
 				}
-			}
 
-			if ( section_control_hide ) {
-				section_control_hide.prev().show();
-				section_control_hide.next().show();
-				if ( section_control_hide.next().hasClass( 'wpsf-section-description' ) ) {
-					section_control_hide.next().next().show();
+				// Tab.
+				if ( 'li' === parent_tag ) {
+					element.closest( 'li' ).hide();
+
+					wpsf.maybe_show_element( element, function() {
+						element.closest( 'li' ).show();
+					} );
 				}
-			}
 
-			// Loop and show if the value is set.
-			$( '*[class*="field-control-group__show-if--"]' ).each( function() {
-				wpsf.show_hide( this, true, 'field' );
-			});
+				// Section.
+				if ( 'div' === parent_tag ) {
+					element.prev().hide();
+					element.next().hide();
+					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
+						element.next().next().hide();
+					}
 
-			$( '*[class*="tab-control-group__show-if--"]' ).each( function() {
-				wpsf.show_hide( this, true, 'tab' );
-			});
-
-			$( '*[class*="section-control-group__show-if--"]' ).each( function() {
-				wpsf.show_hide( this, true, 'section' );
-			});
-
-			// Loop and hide if the value is set.
-			$( '*[class*="field-control-group__hide-if--"]' ).each( function() {
-				wpsf.show_hide( this, false, 'field' );
-			});
-
-			$( '*[class*="tab-control-group__hide-if--"]' ).each( function() {
-				wpsf.show_hide( this, false, 'tab' );
-			});
-
-			$( '*[class*="section-control-group__hide-if--"]' ).each( function() {
-				wpsf.show_hide( this, false, 'section' );
-			});
-
-			$( document.body ).on( 'change', '.field-control-group__controller, .tab-control-group__controller, .section-control-group__controller', wpsf.control_groups );
+					wpsf.maybe_show_element( element, function() {
+						element.prev().show();
+						element.next().show();
+						if ( element.next().hasClass( 'wpsf-section-description' ) ) {
+							element.next().next().show();
+						}
+					} );
+				}
+			} );
 		},
 
 		/**
-		 * Show or hide control.
+		 * Maybe Show Element.
+		 * 
+		 * @param {object} element Element.
+		 * @param {function} callback Callback.
 		 */
-		show_hide: function( control, isShow, type ) {
-			var prefix = type + '-';
-			var parent = 'tab' === type ? 'li' : 'tr';
-			var showHide = isShow ? 'show' : 'hide';
-
-			var classes = control.className.split( /\s+/ );
-			var controller = classes.filter( function( item ) {
-				return item.includes( prefix + 'control-group--' );
-			})[0];
-
-			var values = classes.filter( function( item ) {
-				return item.includes( prefix + 'control-group__' + showHide + '-if--' );
-			}).map( function( item) {
-				return item.replace( prefix + 'control-group__' + showHide + '-if--', '' );
+		maybe_show_element: function( element, callback ) {
+			var classes = element.attr( 'class' ).split( /\s+/ );
+			var controllers = classes.filter( function( item ) {
+				return item.includes( 'show-if--' );
 			});
 
-			var controllerValue = wpsf.get_controller_value( $( '.' + prefix + 'control-group__controller.' + controller ), controller, type );
-			
-			if ( values.includes( controllerValue ) ) {
-				if ( 'section' === type ) {
-					if ( isShow ) {
-						$( control ).prev().show();
-						$( control ).next().show();
-						if ( $( control ).next().hasClass( 'wpsf-section-description' ) ) {
-							$( control ).next().next().show();
+			Array.from( controllers ).forEach( function( control_group ) {
+				var item = control_group.replace( 'show-if--', '' );
+				if ( item.includes( '&&' ) ) {
+					var and_group = item.split( '&&' );
+					var show_item = true;
+					Array.from( and_group ).forEach( function( and_item ) {
+						if ( ! wpsf.get_show_item_bool( show_item, and_item ) ) {
+							show_item = false;
 						}
-					} else {
-						$( control ).prev().hide();
-						$( control ).next().hide();
-						if ( $( control ).next().hasClass( 'wpsf-section-description' ) ) {
-							$( control ).next().next().hide();
-						}
+					});
+
+					if ( show_item ) {
+						callback();
+						return;
 					}
 				} else {
-					if ( isShow ) {
-						$( control ).closest( parent ).show();
-					} else {
-						$( control ).closest( parent ).hide();
+					var show_item = true;
+					show_item = wpsf.get_show_item_bool( show_item, item );
+
+					if ( show_item ) {
+						callback();
+						return;
 					}
 				}
+			});
+		},
+
+		/**
+		 * Get Show Item Bool.
+		 * 
+		 * @param {bool} show Boolean.
+		 * @param {object} item Element.
+		 * @returns {bool}
+		 */
+		get_show_item_bool: function( show = true, item ) {
+			var split = item.split( '===' );
+			var control = split[0];
+			var values = split[1].split( '||' );
+			var control_value = wpsf.get_controller_value( control );
+
+			if ( ! values.includes( control_value ) ) {
+				show = ! show;
 			}
+
+			return show;
 		},
 
 		/** 
 		 * Return the control value.
 		 */
-		get_controller_value: function( controllerControl, controllerId, type ) {
-			var prefix = type + '-';
-
-			if ( 'checkbox' === controllerControl.attr( 'type' ) || 'radio' === controllerControl.attr( 'type' ) ) {
-				controllerControl = $( '.' + prefix + 'control-group__controller.' + controllerId + ':checked' );
+		get_controller_value: function( id ) {
+			var control = $( '#' + id );
+			
+			if ( 'checkbox' === control.attr( 'type' ) || 'radio' === control.attr( 'type' ) ) {
+				control = $( '#' + id + ':checked' );
 			}
 
-			var controllerValue = controllerControl.val();
+			var value = control.val();
 
-			if ( typeof controllerValue === 'undefined' ) {
-				controllerValue = '';
+			if ( typeof value === 'undefined' ) {
+				value = '';
 			}
 
-			return controllerValue.toString();
+			return value.toString();
 		}
 	};
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -18,7 +18,7 @@
 			wpsf.setup_groups();
 			wpsf.tabs.watch();
 			wpsf.watch_submit();
-
+			wpsf.control_groups();
 		},
 
 		/**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -332,6 +332,47 @@
 					} );
 				}
 			} );
+
+			// If hide if, show by default.
+			$( '.hide-if' ).each( function( index ) {
+				var element = $( this );
+				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
+				
+				// Field.
+				if ( 'td' === parent_tag ) {
+					element.closest( 'tr' ).show();
+
+					wpsf.maybe_hide_element( element, function() {
+						element.closest( 'tr' ).hide();
+					} );
+				}
+
+				// Tab.
+				if ( 'li' === parent_tag ) {
+					element.closest( 'li' ).show();
+
+					wpsf.maybe_hide_element( element, function() {
+						element.closest( 'li' ).hide();
+					} );
+				}
+
+				// Section.
+				if ( 'div' === parent_tag ) {
+					element.prev().show();
+					element.next().show();
+					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
+						element.next().next().show();
+					}
+
+					wpsf.maybe_hide_element( element, function() {
+						element.prev().hide();
+						element.next().hide();
+						if ( element.next().hasClass( 'wpsf-section-description' ) ) {
+							element.next().next().hide();
+						}
+					} );
+				}
+			} );
 		},
 
 		/**
@@ -366,6 +407,45 @@
 					show_item = wpsf.get_show_item_bool( show_item, item );
 
 					if ( show_item ) {
+						callback();
+						return;
+					}
+				}
+			});
+		},
+
+		/**
+		 * Maybe Hide Element.
+		 * 
+		 * @param {object} element Element.
+		 * @param {function} callback Callback.
+		 */
+		maybe_hide_element: function( element, callback ) {
+			var classes = element.attr( 'class' ).split( /\s+/ );
+			var controllers = classes.filter( function( item ) {
+				return item.includes( 'hide-if--' );
+			});
+
+			Array.from( controllers ).forEach( function( control_group ) {
+				var item = control_group.replace( 'hide-if--', '' );
+				if ( item.includes( '&&' ) ) {
+					var and_group = item.split( '&&' );
+					var hide_item = true;
+					Array.from( and_group ).forEach( function( and_item ) {
+						if ( ! wpsf.get_show_item_bool( hide_item, and_item ) ) {
+							hide_item = false;
+						}
+					});
+
+					if ( hide_item ) {
+						callback();
+						return;
+					}
+				} else {
+					var hide_item = true;
+					hide_item = wpsf.get_show_item_bool( hide_item, item );
+
+					if ( hide_item ) {
 						callback();
 						return;
 					}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -284,8 +284,94 @@
 
 				$form.submit();
 			} );
-		}
+		},
 
+		/**
+		 * Dynamic control groups.
+		 */
+		control_groups: function() {
+			// Hide all controls that only show if a certain value is set.
+			$( '.control-group__show-if' ).closest( 'tr' ).hide();
+			$( '.tab-control-group__show-if' ).closest( 'li' ).hide();
+
+			// Show all controls that only hide if a certain value is set.
+			$( '.control-group__hide-if' ).closest( 'tr' ).show();
+			$( '.tab-control-group__hide-if' ).closest( 'li' ).show();
+
+			// Loop and show if the value is set.
+			$( '*[class*="control-group__show-if--"]' ).each( function() {
+				wpsf.show_hide( this, true );
+			});
+
+			$( '*[class*="tab-control-group__show-if--"]' ).each( function() {
+				wpsf.show_hide( this, true, true );
+			});
+
+			// Loop and hide if the value is set.
+			$( '*[class*="control-group__hide-if--"]' ).each( function() {
+				wpsf.show_hide( this, false );
+			});
+
+			$( '*[class*="tab-control-group__hide-if--"]' ).each( function() {
+				wpsf.show_hide( this, false, true );
+			});
+
+			$( document.body ).on( 'change', '.control-group__controller, .tab-control-group__controller', wpsf.control_groups );
+		},
+
+		/**
+		 * Show or hide control.
+		 */
+		show_hide: function( control, isShow, isTab ) {
+			var prefix = isTab ? 'tab-' : '';
+			var parent = isTab ? 'li' : 'tr';
+			var showHide = isShow ? 'show' : 'hide';
+
+			var classes = control.className.split( /\s+/ );
+			var controller = classes.filter( function( item ) {
+				return item.includes( prefix + 'control-group--' );
+			})[0];
+
+			var values = classes.filter( function( item ) {
+				return item.includes( prefix + 'control-group__' + showHide + '-if--' );
+			}).map( function( item) {
+				return item.replace( prefix + 'control-group__' + showHide + '-if--', '' );
+			});
+
+			var controllerValue = wpsf.get_controller_value( $( '.' + prefix + 'control-group__controller.' + controller ), controller, isTab );
+			console.log( '.' + prefix + 'control-group__controller.' + controller );
+			console.log( controllerValue );
+			console.log( values );
+			if ( values.includes( controllerValue ) ) {
+				console.log( 'action' );
+				if ( isShow ) {
+					console.log( 'action show' );
+					$( control ).closest( parent ).show();
+				} else {
+					$( control ).closest( parent ).hide();
+					console.log( 'action hide' );
+				}
+			}
+		},
+
+		/** 
+		 * Return the control value.
+		 */
+		get_controller_value: function( controllerControl, controllerId, isTab ) {
+			var prefix = isTab ? 'tab-' : '';
+
+			if ( 'checkbox' === controllerControl.attr( 'type' ) || 'radio' === controllerControl.attr( 'type' ) ) {
+				controllerControl = $( '.' + prefix + 'control-group__controller.' + controllerId + ':checked' );
+			}
+
+			var controllerValue = controllerControl.val();
+
+			if ( typeof controllerValue === 'undefined' ) {
+				controllerValue = '';
+			}
+
+			return controllerValue.toString();
+		}
 	};
 
 	$( document ).ready( wpsf.on_ready() );

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -23,7 +23,9 @@
 add_filter( 'wpsf_register_settings_my_example_settings', 'wpsf_tabless_settings' );
 
 /**
- * Tabless example
+ * Tabless example.
+ * 
+ * @param array $wpsf_settings Settings.
  */
 function wpsf_tabless_settings( $wpsf_settings ) {
 	// General Settings section
@@ -165,7 +167,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 		),
 	);
 
-	// More Settings section
+	// More Settings section.
 	$wpsf_settings[] = array(
 		'section_id'    => 'more',
 		'section_title' => 'More Settings',
@@ -180,58 +182,58 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 			),
 		),
 		array(
-			'id'               => 'control-group',
-			'title'            => 'Control Group',
-			'subtitle'         => 'Selection option 1 or 2 to show and hide controls.',
-			'type'             => 'select',
-			'choices'          => array(
+			'id'              => 'control-group',
+			'title'           => 'Control Group',
+			'subtitle'        => 'Selection option 1 or 2 to show and hide controls.',
+			'type'            => 'select',
+			'choices'         => array(
 				'option-1' => 'Option 1',
 				'option-2' => 'Option 2',
 				'option-3' => 'Option 3',
 			),
-			'default'          => 'text',
-			'showControlGroup' => 'control-group', // Needs to be set to the same control. Does not have to match the Id of this control.
+			'default'         => 'text',
+			'show_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
 		),
 		array(
-			'id'               => 'show-if-option-1',
-			'title'            => 'Show if Option 1',
-			'subtitle'         => 'Will show if Option 1 is set.',
-			'type'             => 'select',
-			'type'             => 'text',
-			'default'          => 'This is default',
-			'showControlGroup' => 'control-group', // Needs to be set to the control group.
-			'showIfValue'      => array( 'option-1' ), // show if will hide the control unless the value matches.
+			'id'                 => 'show-if-option-1',
+			'title'              => 'Show if Option 1',
+			'subtitle'           => 'Will show if Option 1 is set.',
+			'type'               => 'select',
+			'type'               => 'text',
+			'default'            => 'This is default',
+			'show_control_group' => 'control-group', // Needs to be set to the control group.
+			'show_if_value'      => array( 'option-1' ), // show if will hide the control unless the value matches.
 
 		),
 		array(
-			'id'               => 'show-if-option-2',
-			'title'            => 'Show if Option 2',
-			'subtitle'         => 'Will show if Option 2 is set.',
-			'type'             => 'select',
-			'type'             => 'text',
-			'default'          => 'This is default',
-			'showControlGroup' => 'control-group', // Needs to be set to the control group.
-			'showIfValue'      => array( 'option-2' ), // show if will hide the control unless the value matches.
+			'id'                 => 'show-if-option-2',
+			'title'              => 'Show if Option 2',
+			'subtitle'           => 'Will show if Option 2 is set.',
+			'type'               => 'select',
+			'type'               => 'text',
+			'default'            => 'This is default',
+			'show_control_group' => 'control-group', // Needs to be set to the control group.
+			'show_if_value'      => array( 'option-2' ), // show if will hide the control unless the value matches.
 		),
 		array(
-			'id'               => 'show-if-option-2-or-3',
-			'title'            => 'Show if Option 2 or 3',
-			'subtitle'         => 'Will show if Option 2 or 3 is set.',
-			'type'             => 'select',
-			'type'             => 'text',
-			'default'          => 'This is default',
-			'showControlGroup' => 'control-group', // Needs to be set to the control group.
-			'showIfValue'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
+			'id'                 => 'show-if-option-2-or-3',
+			'title'              => 'Show if Option 2 or 3',
+			'subtitle'           => 'Will show if Option 2 or 3 is set.',
+			'type'               => 'select',
+			'type'               => 'text',
+			'default'            => 'This is default',
+			'show_control_group' => 'control-group', // Needs to be set to the control group.
+			'show_if_value'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
 		),
 		array(
-			'id'               => 'hide-if-option-1',
-			'title'            => 'Hide if Option 1',
-			'subtitle'         => 'Will hide if Option 1 is set.',
-			'type'             => 'select',
-			'type'             => 'text',
-			'default'          => 'This is default',
-			'showControlGroup' => 'control-group', // Needs to be set to the control group.
-			'hideIfValue'      => array( 'option-1' ), // hide if will show the control unless the value matches.
+			'id'                 => 'hide-if-option-1',
+			'title'              => 'Hide if Option 1',
+			'subtitle'           => 'Will hide if Option 1 is set.',
+			'type'               => 'select',
+			'type'               => 'text',
+			'default'            => 'This is default',
+			'show_control_group' => 'control-group', // Needs to be set to the control group.
+			'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
 		),
 	);
 
@@ -239,11 +241,12 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 }
 
 /**
- * Tabbed example
+ * Tabbed example.
+ *
+ * @param array $wpsf_settings settings.
  */
-
 function wpsf_tabbed_settings( $wpsf_settings ) {
-	// Tabs
+	// Tabs.
 	$wpsf_settings['tabs'] = array(
 		array(
 			'id'    => 'tab_1',
@@ -254,15 +257,15 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 			'title' => __( 'Tab 2' ),
 		),
 		array(
-			'id'              => 'tab_3',
-			'title'           => __( 'Tab 3' ),
-			'tabControlGroup' => 'tab-control',
-			'showIfValue'     => array( true ), // show if will hide the tab unless the value matches.
-			// 'hideIfValue'  => array( true ), // hide if will show the tab unless the value matches.
+			'id'                => 'tab_3',
+			'title'             => __( 'Tab 3' ),
+			'tab_control_group' => 'tab-control',
+			'show_if_value'     => array( true ), // show if will hide the tab unless the value matches.
+			// 'hide_if_value'  => array( true ), // hide if will show the tab unless the value matches.
 		),
 	);
 
-	// Settings
+	// Settings.
 	$wpsf_settings['sections'] = array(
 		array(
 			'tab_id'        => 'tab_1',
@@ -309,11 +312,11 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 				),
 			),
 			array(
-				'id'              => 'tab-control',
-				'title'           => __( 'Will show Tab 3 if toggled', 'flux-checkout' ),
-				'type'            => 'toggle',
-				'default'         => false,
-				'tabControlGroup' => 'tab-control', // Needs to be set to the same tab control. Does not have to match the Id of this control. 
+				'id'             => 'tab-control',
+				'title'          => __( 'Will show Tab 3 if toggled', 'flux-checkout' ),
+				'type'           => 'toggle',
+				'default'        => false,
+				'tab_controller' => 'tab-control', // Needs to be set to the same tab control group. Does not have to match the Id of this control.
 			),
 		),
 		array(

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -63,10 +63,10 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'datepicker' => array(), // Array of datepicker options (http://api.jqueryui.com/datepicker/)
 			),
 			array(
-				'id'         => 'group',
-				'title'      => 'Group',
-				'desc'       => 'This is a description.',
-				'type'       => 'group',
+				'id'        => 'group',
+				'title'     => 'Group',
+				'desc'      => 'This is a description.',
+				'type'      => 'group',
 				'subfields' => array(
 					// accepts most types of fields
 					array(
@@ -77,7 +77,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 						'type'        => 'text',
 						'default'     => 'Sub text',
 					),
-				)
+				),
 			),
 			array(
 				'id'          => 'password',
@@ -179,6 +179,60 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default' => 'This is default',
 			),
 		),
+		array(
+			'id'               => 'control-group',
+			'title'            => 'Control Group',
+			'subtitle'         => 'Selection option 1 or 2 to show and hide controls.',
+			'type'             => 'select',
+			'choices'          => array(
+				'option-1' => 'Option 1',
+				'option-2' => 'Option 2',
+				'option-3' => 'Option 3',
+			),
+			'default'          => 'text',
+			'showControlGroup' => 'control-group', // Needs to be set to the same control. Does not have to match the Id of this control.
+		),
+		array(
+			'id'               => 'show-if-option-1',
+			'title'            => 'Show if Option 1',
+			'subtitle'         => 'Will show if Option 1 is set.',
+			'type'             => 'select',
+			'type'             => 'text',
+			'default'          => 'This is default',
+			'showControlGroup' => 'control-group', // Needs to be set to the control group.
+			'showIfValue'      => array( 'option-1' ), // show if will hide the control unless the value matches.
+
+		),
+		array(
+			'id'               => 'show-if-option-2',
+			'title'            => 'Show if Option 2',
+			'subtitle'         => 'Will show if Option 2 is set.',
+			'type'             => 'select',
+			'type'             => 'text',
+			'default'          => 'This is default',
+			'showControlGroup' => 'control-group', // Needs to be set to the control group.
+			'showIfValue'      => array( 'option-2' ), // show if will hide the control unless the value matches.
+		),
+		array(
+			'id'               => 'show-if-option-2-or-3',
+			'title'            => 'Show if Option 2 or 3',
+			'subtitle'         => 'Will show if Option 2 or 3 is set.',
+			'type'             => 'select',
+			'type'             => 'text',
+			'default'          => 'This is default',
+			'showControlGroup' => 'control-group', // Needs to be set to the control group.
+			'showIfValue'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
+		),
+		array(
+			'id'               => 'hide-if-option-1',
+			'title'            => 'Hide if Option 1',
+			'subtitle'         => 'Will hide if Option 1 is set.',
+			'type'             => 'select',
+			'type'             => 'text',
+			'default'          => 'This is default',
+			'showControlGroup' => 'control-group', // Needs to be set to the control group.
+			'hideIfValue'      => array( 'option-1' ), // hide if will show the control unless the value matches.
+		),
 	);
 
 	return $wpsf_settings;
@@ -198,6 +252,13 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 		array(
 			'id'    => 'tab_2',
 			'title' => __( 'Tab 2' ),
+		),
+		array(
+			'id'              => 'tab_3',
+			'title'           => __( 'Tab 3' ),
+			'tabControlGroup' => 'tab-control',
+			'showIfValue'     => array( true ), // show if will hide the tab unless the value matches.
+			// 'hideIfValue'  => array( true ), // hide if will show the tab unless the value matches.
 		),
 	);
 
@@ -241,6 +302,28 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 			'fields'        => array(
 				array(
 					'id'      => 'text-3',
+					'title'   => 'Text',
+					'desc'    => 'This is a description.',
+					'type'    => 'text',
+					'default' => 'This is default',
+				),
+			),
+			array(
+				'id'              => 'tab-control',
+				'title'           => __( 'Will show Tab 3 if toggled', 'flux-checkout' ),
+				'type'            => 'toggle',
+				'default'         => false,
+				'tabControlGroup' => 'tab-control', // Needs to be set to the same tab control. Does not have to match the Id of this control. 
+			),
+		),
+		array(
+			'tab_id'        => 'tab_3',
+			'section_id'    => 'section_4',
+			'section_title' => 'Section 4',
+			'section_order' => 10,
+			'fields'        => array(
+				array(
+					'id'      => 'text-4',
 					'title'   => 'Text',
 					'desc'    => 'This is a description.',
 					'type'    => 'text',

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -180,60 +180,60 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'    => 'text',
 				'default' => 'This is default',
 			),
-		),
-		array(
-			'id'              => 'control-group',
-			'title'           => 'Control Group',
-			'subtitle'        => 'Selection option 1 or 2 to show and hide controls.',
-			'type'            => 'select',
-			'choices'         => array(
-				'option-1' => 'Option 1',
-				'option-2' => 'Option 2',
-				'option-3' => 'Option 3',
+			array(
+				'id'              => 'control-group',
+				'title'           => 'Control Group',
+				'subtitle'        => 'Selection option 1 or 2 to show and hide controls.',
+				'type'            => 'select',
+				'choices'         => array(
+					'option-1' => 'Option 1',
+					'option-2' => 'Option 2',
+					'option-3' => 'Option 3',
+				),
+				'default'         => 'text',
+				'show_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
 			),
-			'default'         => 'text',
-			'show_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
-		),
-		array(
-			'id'                 => 'show-if-option-1',
-			'title'              => 'Show if Option 1',
-			'subtitle'           => 'Will show if Option 1 is set.',
-			'type'               => 'select',
-			'type'               => 'text',
-			'default'            => 'This is default',
-			'show_control_group' => 'control-group', // Needs to be set to the control group.
-			'show_if_value'      => array( 'option-1' ), // show if will hide the control unless the value matches.
+			array(
+				'id'                 => 'show-if-option-1',
+				'title'              => 'Show if Option 1',
+				'subtitle'           => 'Will show if Option 1 is set.',
+				'type'               => 'select',
+				'type'               => 'text',
+				'default'            => 'This is default',
+				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'show_if_value'      => array( 'option-1' ), // show if will hide the control unless the value matches.
 
-		),
-		array(
-			'id'                 => 'show-if-option-2',
-			'title'              => 'Show if Option 2',
-			'subtitle'           => 'Will show if Option 2 is set.',
-			'type'               => 'select',
-			'type'               => 'text',
-			'default'            => 'This is default',
-			'show_control_group' => 'control-group', // Needs to be set to the control group.
-			'show_if_value'      => array( 'option-2' ), // show if will hide the control unless the value matches.
-		),
-		array(
-			'id'                 => 'show-if-option-2-or-3',
-			'title'              => 'Show if Option 2 or 3',
-			'subtitle'           => 'Will show if Option 2 or 3 is set.',
-			'type'               => 'select',
-			'type'               => 'text',
-			'default'            => 'This is default',
-			'show_control_group' => 'control-group', // Needs to be set to the control group.
-			'show_if_value'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
-		),
-		array(
-			'id'                 => 'hide-if-option-1',
-			'title'              => 'Hide if Option 1',
-			'subtitle'           => 'Will hide if Option 1 is set.',
-			'type'               => 'select',
-			'type'               => 'text',
-			'default'            => 'This is default',
-			'show_control_group' => 'control-group', // Needs to be set to the control group.
-			'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
+			),
+			array(
+				'id'                 => 'show-if-option-2',
+				'title'              => 'Show if Option 2',
+				'subtitle'           => 'Will show if Option 2 is set.',
+				'type'               => 'select',
+				'type'               => 'text',
+				'default'            => 'This is default',
+				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'show_if_value'      => array( 'option-2' ), // show if will hide the control unless the value matches.
+			),
+			array(
+				'id'                 => 'show-if-option-2-or-3',
+				'title'              => 'Show if Option 2 or 3',
+				'subtitle'           => 'Will show if Option 2 or 3 is set.',
+				'type'               => 'select',
+				'type'               => 'text',
+				'default'            => 'This is default',
+				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'show_if_value'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
+			),
+			array(
+				'id'                 => 'hide-if-option-1',
+				'title'              => 'Hide if Option 1',
+				'subtitle'           => 'Will hide if Option 1 is set.',
+				'type'               => 'select',
+				'type'               => 'text',
+				'default'            => 'This is default',
+				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
+			),
 		),
 	);
 

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -24,7 +24,7 @@ add_filter( 'wpsf_register_settings_my_example_settings', 'wpsf_tabless_settings
 
 /**
  * Tabless example.
- * 
+ *
  * @param array $wpsf_settings Settings.
  */
 function wpsf_tabless_settings( $wpsf_settings ) {
@@ -173,7 +173,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 		'section_title' => 'More Settings',
 		'section_order' => 10,
 		'fields'        => array(
-			array( 
+			array(
 				'id'       => 'heading-tooltip-link',
 				'title'    => 'Heading with tooltip',
 				'subtitle' => 'Lorem ipsum dolor sit amet congue aliqua scelerisque dictumst ornare nullam suspendisse.',
@@ -209,65 +209,79 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default' => 'This is default',
 			),
 			array(
-				'id'              => 'control-group',
-				'title'           => 'Control Group',
-				'subtitle'        => 'Selection option 1 or 2 to show and hide controls.',
-				'type'            => 'select',
-				'choices'         => array(
+				'id'       => 'control-group',
+				'title'    => 'Control Group',
+				'subtitle' => 'Select option 1 or 2 to show and hide controls.',
+				'type'     => 'select',
+				'choices'  => array(
 					'option-1' => 'Option 1',
 					'option-2' => 'Option 2',
 					'option-3' => 'Option 3',
 				),
-				'default'         => 'text',
-				'field_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
+				'default'  => 'text',
 			),
 			array(
-				'id'                 => 'show-if-option-1',
-				'title'              => 'Show if Option 1',
-				'subtitle'           => 'Will show if Option 1 is set.',
-				'type'               => 'select',
-				'type'               => 'text',
-				'default'            => 'This is default',
-				'field_control_group' => 'control-group', // Needs to be set to the control group.
-				'show_if_value'      => array( 'option-1' ), // show if will hide the control unless the value matches.
-
+				'id'       => 'show-if-option-1',
+				'title'    => 'Show if Option 1',
+				'subtitle' => 'Will show if Option 1 is set.',
+				'type'     => 'select',
+				'type'     => 'text',
+				'default'  => 'This is default',
+				'show_if'  => array( // Field will only show, if the control `more_control-group` is set to Option 1.
+					array(
+						'field' => 'more_control-group',
+						'value' => array( 'option-1' ),
+					),
+				),
 			),
 			array(
-				'id'                 => 'show-if-option-2',
-				'title'              => 'Show if Option 2',
-				'subtitle'           => 'Will show if Option 2 is set.',
-				'type'               => 'select',
-				'type'               => 'text',
-				'default'            => 'This is default',
-				'field_control_group' => 'control-group', // Needs to be set to the control group.
-				'show_if_value'      => array( 'option-2' ), // show if will hide the control unless the value matches.
+				'id'       => 'show-if-option-2',
+				'title'    => 'Show if Option 2',
+				'subtitle' => 'Will show if Option 2 is set.',
+				'type'     => 'select',
+				'type'     => 'text',
+				'default'  => 'This is default',
+				'show_if'  => array( // Field will only show, if the control `more_control-group` is set to Option 2.
+					array(
+						'field' => 'more_control-group',
+						'value' => array( 'option-2' ),
+					),
+				),
 			),
 			array(
-				'id'                 => 'show-if-option-2-or-3',
-				'title'              => 'Show if Option 2 or 3',
-				'subtitle'           => 'Will show if Option 2 or 3 is set.',
-				'type'               => 'select',
-				'type'               => 'text',
-				'default'            => 'This is default',
-				'field_control_group' => 'control-group', // Needs to be set to the control group.
-				'show_if_value'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
+				'id'       => 'show-if-option-2-or-3',
+				'title'    => 'Show if Option 2 or 3',
+				'subtitle' => 'Will show if Option 2 or 3 is set.',
+				'type'     => 'select',
+				'type'     => 'text',
+				'default'  => 'This is default',
+				'show_if'  => array( // Field will only show, if the control `more_control-group` is set to Option 2 or Option 3.
+					array(
+						'field' => 'more_control-group',
+						'value' => array( 'option-2', 'option-3' ),
+					),
+				),
 			),
 			array(
-				'id'                 => 'hide-if-option-1',
-				'title'              => 'Hide if Option 1',
-				'subtitle'           => 'Will hide if Option 1 is set.',
-				'type'               => 'select',
-				'type'               => 'text',
-				'default'            => 'This is default',
-				'field_control_group' => 'control-group', // Needs to be set to the control group.
-				'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
+				'id'       => 'hide-if-option-1',
+				'title'    => 'Hide if Option 1',
+				'subtitle' => 'Will hide if Option 1 is set.',
+				'type'     => 'select',
+				'type'     => 'text',
+				'default'  => 'This is default',
+				'hide_if'  => array( // Field will only hide, if the control `more_control-group` is set to Option 1.
+					array(
+						'field' => 'more_control-group',
+						'value' => array( 'option-1' ),
+					),
+				),
 			),
 			array(
-				'id'                 => 'section-control',
-				'title'              => 'Will show Additional Settings Group if toggled', 'flux-checkout',
-				'type'               => 'toggle',
-				'default'            => false,
-				'section_controller' => 'section-control', // Needs to be set to the same section control group. Does not have to match the Id of this control.
+				'id'      => 'section-control',
+				'title'   => 'Will show Additional Settings Group if toggled',
+				'flux-checkout',
+				'type'    => 'toggle',
+				'default' => false,
 			),
 		),
 	);
@@ -277,9 +291,13 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 		'section_title'         => 'Additional Settings',
 		'section_order'         => 10,
 		'section_control_group' => 'section-control',
-		'show_if_value'      => array( true ),
-		// 'hide_if_value'      => array( true ),
-		'fields'        => array(
+		'show_if'               => array( // Field will only show, if the control `more_section-control` is set to true.
+			array(
+				'field' => 'more_section-control',
+				'value' => array( '1' ),
+			),
+		),
+		'fields'                => array(
 			array(
 				'id'      => 'additional-text',
 				'title'   => 'Additional Text',
@@ -320,8 +338,12 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 			'id'                => 'tab_3',
 			'title'             => __( 'Tab 3' ),
 			'tab_control_group' => 'tab-control',
-			'show_if_value'     => array( true ), // show if will hide the tab unless the value matches.
-			// 'hide_if_value'  => array( true ), // hide if will show the tab unless the value matches.
+			'show_if'           => array( // Field will only show if the control `tab_2_section_2_tab-control` is set to true.
+				array(
+					'field' => 'tab_2_section_3_tab-control',
+					'value' => array( '1' ),
+				),
+			),
 		),
 	);
 
@@ -370,13 +392,12 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 					'type'    => 'text',
 					'default' => 'This is default',
 				),
-			),
-			array(
-				'id'             => 'tab-control',
-				'title'          => 'Will show Tab 3 if toggled',
-				'type'           => 'toggle',
-				'default'        => false,
-				'tab_controller' => 'tab-control', // Needs to be set to the same tab control group. Does not have to match the Id of this control.
+				array(
+					'id'      => 'tab-control',
+					'title'   => 'Will show Tab 3 if toggled',
+					'type'    => 'toggle',
+					'default' => false,
+				),
 			),
 		),
 		array(
@@ -391,6 +412,88 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 					'desc'    => 'This is a description.',
 					'type'    => 'text',
 					'default' => 'This is default',
+				),
+				array(
+					'id'       => 'complex-group-1',
+					'title'    => 'Complex Show Hide 1',
+					'subtitle' => 'Multiple controls can show or hide fields',
+					'type'     => 'select',
+					'choices'  => array(
+						'option-1' => 'Option 1',
+						'option-2' => 'Option 2',
+						'option-3' => 'Option 3',
+					),
+					'default'  => 'text',
+				),
+				array(
+					'id'       => 'complex-group-2',
+					'title'    => 'Complex Show Hide 2',
+					'subtitle' => 'Multiple controls can show or hide fields',
+					'type'     => 'toggle',
+					'default'  => false,
+				),
+				array(
+					'id'       => 'complex-group-3',
+					'title'    => 'Complex Show Hide 3',
+					'subtitle' => 'Multiple controls can show or hide fields',
+					'type'     => 'toggle',
+					'default'  => false,
+				),
+				array(
+					'id'       => 'complex-group-show',
+					'title'    => 'Complex Show Example',
+					'subtitle' => 'Will show if Control 1 is Option 1 or Option 2 AND Control 2 is True, OR if Control 3 is true',
+					'type'     => 'select',
+					'type'     => 'text',
+					'default'  => 'This is default',
+					'show_if'  => array(
+						// An array here is an AND group.
+						array(
+							// Show if Control 1 is Option 1 OR Option 2.
+							array(
+								'field' => 'tab_3_section_4_complex-group-1',
+								'value' => array( 'option-1', 'option-2' ),
+							),
+							// AND Control 2 is True.
+							array(
+								'field' => 'tab_3_section_4_complex-group-2',
+								'value' => array( '1' ),
+							),
+						),
+						// OR show if Control 3 is True.
+						array(
+							'field' => 'tab_3_section_4_complex-group-3',
+							'value' => array( '1' ),
+						),
+					),
+				),
+				array(
+					'id'       => 'complex-group-hide',
+					'title'    => 'Complex Hide Example',
+					'subtitle' => 'Will hide if Control 1 is Option 1 or Option 2 AND Control 2 is True, OR if Control 3 is true',
+					'type'     => 'select',
+					'type'     => 'text',
+					'default'  => 'This is default',
+					'hide_if'  => array(
+						// An array here is an AND group.
+						array(
+							// Hide if Control 1 is Option 1 OR Option 2.
+							array(
+								'field' => 'tab_3_section_4_complex-group-1',
+								'value' => array( 'option-1', 'option-2' ),
+							),
+							// AND Control 2 is True.
+							array(
+								'field' => 'tab_3_section_4_complex-group-2',
+								'value' => array( '1' ),
+							),
+						),
+						// OR hide if Control 3 is True.
+						array(
+							'field' => 'tab_3_section_4_complex-group-3',
+							'value' => array( '1' ),
+						),
+					),
 				),
 			),
 		),

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -234,6 +234,38 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'show_control_group' => 'control-group', // Needs to be set to the control group.
 				'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
 			),
+			array(
+				'id'                 => 'section-control',
+				'title'              => 'Will show Additional Settings Group if toggled', 'flux-checkout',
+				'type'               => 'toggle',
+				'default'            => false,
+				'section_controller' => 'section-control', // Needs to be set to the same section control group. Does not have to match the Id of this control.
+			),
+		),
+	);
+
+	$wpsf_settings[] = array(
+		'section_id'            => 'additional',
+		'section_title'         => 'Additional Settings',
+		'section_order'         => 10,
+		'section_control_group' => 'section-control',
+		'show_if_value'      => array( true ),
+		// 'hide_if_value'      => array( true ),
+		'fields'        => array(
+			array(
+				'id'      => 'additional-text',
+				'title'   => 'Additional Text',
+				'desc'    => 'This is a description.',
+				'type'    => 'text',
+				'default' => 'This is default',
+			),
+			array(
+				'id'      => 'additional-number',
+				'title'   => 'Additional Number',
+				'desc'    => 'This is a description.',
+				'type'    => 'number',
+				'default' => 10,
+			),
 		),
 	);
 
@@ -313,7 +345,7 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 			),
 			array(
 				'id'             => 'tab-control',
-				'title'          => __( 'Will show Tab 3 if toggled', 'flux-checkout' ),
+				'title'          => 'Will show Tab 3 if toggled',
 				'type'           => 'toggle',
 				'default'        => false,
 				'tab_controller' => 'tab-control', // Needs to be set to the same tab control group. Does not have to match the Id of this control.

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -219,7 +219,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 					'option-3' => 'Option 3',
 				),
 				'default'         => 'text',
-				'show_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
+				'field_controller' => 'control-group', // Needs to be set to the same as the control group. Does not have to match the Id of this control.
 			),
 			array(
 				'id'                 => 'show-if-option-1',
@@ -228,7 +228,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'               => 'select',
 				'type'               => 'text',
 				'default'            => 'This is default',
-				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'field_control_group' => 'control-group', // Needs to be set to the control group.
 				'show_if_value'      => array( 'option-1' ), // show if will hide the control unless the value matches.
 
 			),
@@ -239,7 +239,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'               => 'select',
 				'type'               => 'text',
 				'default'            => 'This is default',
-				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'field_control_group' => 'control-group', // Needs to be set to the control group.
 				'show_if_value'      => array( 'option-2' ), // show if will hide the control unless the value matches.
 			),
 			array(
@@ -249,7 +249,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'               => 'select',
 				'type'               => 'text',
 				'default'            => 'This is default',
-				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'field_control_group' => 'control-group', // Needs to be set to the control group.
 				'show_if_value'      => array( 'option-2', 'option-3' ), // show if will hide the control unless the value matches.
 			),
 			array(
@@ -259,7 +259,7 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'               => 'select',
 				'type'               => 'text',
 				'default'            => 'This is default',
-				'show_control_group' => 'control-group', // Needs to be set to the control group.
+				'field_control_group' => 'control-group', // Needs to be set to the control group.
 				'hide_if_value'      => array( 'option-1' ), // hide if will show the control unless the value matches.
 			),
 			array(

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -419,10 +419,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$args['name']  = $this->generate_field_name( $args['id'] );
 
 			// Create classes from show/hide values.
-			if ( $args['show_controller'] ) {
-				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['show_controller'] );
-				$args['class'] .= ' control-group__controller';
+			if ( $args['field_controller'] ) {
+				$args['class'] .= ' field-control-group';
+				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_controller'] );
+				$args['class'] .= ' field-control-group__controller';
 			}
 
 			if ( $args['tab_controller'] ) {
@@ -437,11 +437,11 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				$args['class'] .= ' section-control-group__controller';
 			}
 
-			if ( ! empty( $args['show_if_value'] ) && esc_attr( $args['show_control_group'] ) ) {
-				$class = ' control-group__show-if';
+			if ( ! empty( $args['show_if_value'] ) && esc_attr( $args['field_control_group'] ) ) {
+				$class = ' field-control-group__show-if';
 
-				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['show_control_group'] );
+				$args['class'] .= ' field-control-group';
+				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_control_group'] );
 				$args['class'] .= $class;
 
 				foreach ( $args['show_if_value'] as $value ) {
@@ -449,11 +449,11 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				}
 			}
 
-			if ( ! empty( $args['hide_if_value'] ) && esc_attr( $args['show_control_group'] ) ) {
-				$class = ' control-group__hide-if';
+			if ( ! empty( $args['hide_if_value'] ) && esc_attr( $args['field_control_group'] ) ) {
+				$class = ' field-control-group__hide-if';
 
-				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['show_control_group'] );
+				$args['class'] .= ' field-control-group';
+				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_control_group'] );
 				$args['class'] .= $class;
 
 				foreach ( $args['hide_if_value'] as $value ) {

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -289,6 +289,34 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			if ( ! empty( $this->settings ) ) {
 				foreach ( $this->settings as $section ) {
 					if ( $section['section_id'] == $args['id'] ) {
+						$renderClass = '';
+						if ( ! empty( $section['show_if_value'] ) && esc_attr( $section['section_control_group'] ) ) {
+							$class = ' section-control-group__show-if';
+			
+							$renderClass .= ' section-control-group';
+							$renderClass .= ' section-control-group--' . esc_attr( $section['section_control_group'] );
+							$renderClass .= $class;
+			
+							foreach ( $section['show_if_value'] as $value ) {
+								$renderClass .= $class . '--' . $value;
+							}
+						}
+			
+						if ( ! empty( $section['hide_if_value'] ) && esc_attr( $section['section_control_group'] ) ) {
+
+							$class = ' section-control-group__hide-if';
+			
+							$renderClass .= ' section-control-group';
+							$renderClass .= ' section-control-group--' . esc_attr( $section['section_control_group'] );
+							$renderClass .= $class;
+			
+							foreach ( $section['hide_if_value'] as $value ) {
+								$renderClass .= $class . '--' . $value;
+							}
+						}
+						if ( $renderClass ) {
+							echo '<span class="' . esc_attr( $renderClass ) . '"></span>';
+						}
 						if ( isset( $section['section_description'] ) && $section['section_description'] ) {
 							echo '<div class="wpsf-section-description wpsf-section-description--' . esc_attr( $section['section_id'] ) . '">' . $section['section_description'] . '</div>';
 						}
@@ -369,6 +397,12 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				$args['class'] .= ' tab-control-group';
 				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tab_controller'] );
 				$args['class'] .= ' tab-control-group__controller';
+			}
+
+			if ( $args['section_controller'] ) {
+				$args['class'] .= ' section-control-group';
+				$args['class'] .= ' section-control-group--' . esc_attr( $args['section_controller'] );
+				$args['class'] .= ' section-control-group__controller';
 			}
 
 			if ( ! empty( $args['show_if_value'] ) && esc_attr( $args['show_control_group'] ) ) {

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -328,10 +328,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		/**
 		 * Usort callback. Sorts $this->settings by "section_order"
 		 *
-		 * @param $a
-		 * @param $b
+		 * @param array $a Sortable Array.
+		 * @param array $b Sortable Array.
 		 *
-		 * @return int
+		 * @return array
 		 */
 		public function sort_array( $a, $b ) {
 			if ( ! isset( $a['section_order'] ) ) {
@@ -344,7 +344,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		/**
 		 * Generates the HTML output of the settings fields
 		 *
-		 * @param array callback args from add_settings_field()
+		 * @param array $args callback args from add_settings_field()
 		 */
 		public function generate_setting( $args ) {
 			$section                = $args['section'];
@@ -359,38 +359,38 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$args['name']  = $this->generate_field_name( $args['id'] );
 
 			// Create classes from show/hide values.
-			if ( $args['showControlGroup'] && empty( $args['showIfValue'] ) && empty( $args['hideIfValue'] ) ) {
+			if ( $args['show_controller'] ) {
 				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= ' control-group--' . esc_attr( $args['show_controller'] );
 				$args['class'] .= ' control-group__controller';
 			}
 
-			if ( $args['tabControlGroup'] ) {
+			if ( $args['tab_control_group'] ) {
 				$args['class'] .= ' tab-control-group';
-				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tabControlGroup'] );
+				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tab_control_group'] );
 				$args['class'] .= ' tab-control-group__controller';
 			}
 
-			if ( ! empty( $args['showIfValue'] ) && esc_attr( $args['showControlGroup'] ) ) {
+			if ( ! empty( $args['show_if_value'] ) && esc_attr( $args['show_control_group'] ) ) {
 				$class = ' control-group__show-if';
 
 				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= ' control-group--' . esc_attr( $args['show_control_group'] );
 				$args['class'] .= $class;
 
-				foreach ( $args['showIfValue'] as $value ) {
+				foreach ( $args['show_if_value'] as $value ) {
 					$args['class'] .= $class . '--' . $value;
 				}
 			}
 
-			if ( ! empty( $args['hideIfValue'] ) && esc_attr( $args['showControlGroup'] ) ) {
+			if ( ! empty( $args['hide_if_value'] ) && esc_attr( $args['show_control_group'] ) ) {
 				$class = ' control-group__hide-if';
 
 				$args['class'] .= ' control-group';
-				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= ' control-group--' . esc_attr( $args['show_control_group'] );
 				$args['class'] .= $class;
 
-				foreach ( $args['hideIfValue'] as $value ) {
+				foreach ( $args['hide_if_value'] as $value ) {
 					$args['class'] .= $class . '--' . $value;
 				}
 			}
@@ -959,32 +959,32 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 					}
 
 					// Create classes from show/hide values.
-					if ( $tab_data['tabControlGroup'] && empty( $tab_data['showIfValue'] ) && empty( $tab_data['hideIfValue'] ) ) {
+					if ( $tab_data['tab_controller'] ) {
 						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_controller'] );
 						$tab_data['class'] .= ' tab-control-group__controller';
 					}
 
-					if ( ! empty( $tab_data['showIfValue'] ) && esc_attr( $tab_data['tabControlGroup'] ) ) {
+					if ( ! empty( $tab_data['show_if_value'] ) && esc_attr( $tab_data['tab_control_group'] ) ) {
 						$class = ' tab-control-group__show-if';
 
 						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
 						$tab_data['class'] .= $class;
 
-						foreach ( $tab_data['showIfValue'] as $value ) {
+						foreach ( $tab_data['show_if_value'] as $value ) {
 							$tab_data['class'] .= $class . '--' . $value;
 						}
 					}
 
-					if ( ! empty( $tab_data['hideIfValue'] ) && esc_attr( $tab_data['tabControlGroup'] ) ) {
+					if ( ! empty( $tab_data['hide_if_value'] ) && esc_attr( $tab_data['tab_control_group'] ) ) {
 						$class = ' tab-control-group__hide-if';
 
 						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
 						$tab_data['class'] .= $class;
 
-						foreach ( $tab_data['hideIfValue'] as $value ) {
+						foreach ( $tab_data['hide_if_value'] as $value ) {
 							$tab_data['class'] .= $class . '--' . $value;
 						}
 					}

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -290,30 +290,9 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				foreach ( $this->settings as $section ) {
 					if ( $section['section_id'] == $args['id'] ) {
 						$renderClass = '';
-						if ( ! empty( $section['show_if_value'] ) && esc_attr( $section['section_control_group'] ) ) {
-							$class = ' section-control-group__show-if';
-			
-							$renderClass .= ' section-control-group';
-							$renderClass .= ' section-control-group--' . esc_attr( $section['section_control_group'] );
-							$renderClass .= $class;
-			
-							foreach ( $section['show_if_value'] as $value ) {
-								$renderClass .= $class . '--' . $value;
-							}
-						}
-			
-						if ( ! empty( $section['hide_if_value'] ) && esc_attr( $section['section_control_group'] ) ) {
 
-							$class = ' section-control-group__hide-if';
-			
-							$renderClass .= ' section-control-group';
-							$renderClass .= ' section-control-group--' . esc_attr( $section['section_control_group'] );
-							$renderClass .= $class;
-			
-							foreach ( $section['hide_if_value'] as $value ) {
-								$renderClass .= $class . '--' . $value;
-							}
-						}
+						$renderClass .= self::add_show_hide_classes( $section );
+
 						if ( $renderClass ) {
 							echo '<span class="' . esc_attr( $renderClass ) . '"></span>';
 						}
@@ -418,48 +397,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$args['value'] = isset( $options[ $args['id'] ] ) ? $options[ $args['id'] ] : ( isset( $args['default'] ) ? $args['default'] : '' );
 			$args['name']  = $this->generate_field_name( $args['id'] );
 
-			// Create classes from show/hide values.
-			if ( $args['field_controller'] ) {
-				$args['class'] .= ' field-control-group';
-				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_controller'] );
-				$args['class'] .= ' field-control-group__controller';
-			}
-
-			if ( $args['tab_controller'] ) {
-				$args['class'] .= ' tab-control-group';
-				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tab_controller'] );
-				$args['class'] .= ' tab-control-group__controller';
-			}
-
-			if ( $args['section_controller'] ) {
-				$args['class'] .= ' section-control-group';
-				$args['class'] .= ' section-control-group--' . esc_attr( $args['section_controller'] );
-				$args['class'] .= ' section-control-group__controller';
-			}
-
-			if ( ! empty( $args['show_if_value'] ) && esc_attr( $args['field_control_group'] ) ) {
-				$class = ' field-control-group__show-if';
-
-				$args['class'] .= ' field-control-group';
-				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_control_group'] );
-				$args['class'] .= $class;
-
-				foreach ( $args['show_if_value'] as $value ) {
-					$args['class'] .= $class . '--' . $value;
-				}
-			}
-
-			if ( ! empty( $args['hide_if_value'] ) && esc_attr( $args['field_control_group'] ) ) {
-				$class = ' field-control-group__hide-if';
-
-				$args['class'] .= ' field-control-group';
-				$args['class'] .= ' field-control-group--' . esc_attr( $args['field_control_group'] );
-				$args['class'] .= $class;
-
-				foreach ( $args['hide_if_value'] as $value ) {
-					$args['class'] .= $class . '--' . $value;
-				}
-			}
+			$args['class'] .= self::add_show_hide_classes( $args );
 
 			do_action( 'wpsf_before_field_' . $this->option_group );
 			do_action( 'wpsf_before_field_' . $this->option_group . '_' . $args['id'] );
@@ -1028,36 +966,7 @@ endwhile;
 						$tab_data['class'] = '';
 					}
 
-					// Create classes from show/hide values.
-					if ( $tab_data['tab_control_group'] ) {
-						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
-						// $tab_data['class'] .= ' tab-control-group__controller';
-					}
-
-					if ( ! empty( $tab_data['show_if_value'] ) && esc_attr( $tab_data['tab_control_group'] ) ) {
-						$class = ' tab-control-group__show-if';
-
-						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
-						$tab_data['class'] .= $class;
-
-						foreach ( $tab_data['show_if_value'] as $value ) {
-							$tab_data['class'] .= $class . '--' . $value;
-						}
-					}
-
-					if ( ! empty( $tab_data['hide_if_value'] ) && esc_attr( $tab_data['tab_control_group'] ) ) {
-						$class = ' tab-control-group__hide-if';
-
-						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
-						$tab_data['class'] .= $class;
-
-						foreach ( $tab_data['hide_if_value'] as $value ) {
-							$tab_data['class'] .= $class . '--' . $value;
-						}
-					}
+					$tab_data['class'] .= self::add_show_hide_classes( $tab_data );
 
 					$active = $i == 0 ? 'wpsf-nav__item--active' : '';
 					?>
@@ -1111,6 +1020,66 @@ endwhile;
 			}
 
 			return false;
+		}
+
+		/**
+		 * Add Show Hide Classes.
+		 */
+		public static function add_show_hide_classes( $args, $type = 'show_if' ) {
+			$class = '';
+			$slug  = ' ' . str_replace( '_', '-', $type );
+			if ( isset( $args[ $type ] ) && is_array( $args[ $type ] ) ) {
+				$class .= $slug;
+				foreach ( $args[ $type ] as $condition ) {
+					if ( isset( $condition['field'] ) && $condition['value'] ) {
+						$value_string = '';
+						foreach ( $condition['value'] as $value ) {
+							if ( ! empty( $value_string ) ) {
+								$value_string .= '||';
+							}
+							$value_string .= $value;
+						}
+
+						if ( ! empty( $value_string ) ) {
+							$class .= $slug . '--' . $condition['field'] . '===' . $value_string;
+						}
+					} else {
+						$and_string = '';
+						foreach( $condition as $and_condition ) {
+							if ( ! isset( $and_condition['field'] ) || ! isset( $and_condition['value'] ) ) {
+								continue;
+							}
+
+							if ( ! empty( $and_string ) ) {
+								$and_string .= '&&';
+							}
+
+							$value_string = '';
+							foreach ( $and_condition['value'] as $value ) {
+								if ( ! empty( $value_string ) ) {
+									$value_string .= '||';
+								}
+								$value_string .= $value;
+							}
+
+							if ( ! empty( $value_string ) ) {
+								$and_string .= $and_condition['field'] . '===' . $value_string;
+							}
+						}
+
+						if ( ! empty( $and_string ) ) {
+							$class .= $slug . '--' . $and_string;
+						}
+					}
+				}
+			}
+
+			// Run the function again with hide if.
+			if ( 'hide_if' !== $type ) {
+				$class .= self::add_show_hide_classes( $args, 'hide_if' );
+			}
+
+			return $class;
 		}
 	}
 }

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -358,6 +358,43 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$args['value'] = isset( $options[ $args['id'] ] ) ? $options[ $args['id'] ] : ( isset( $args['default'] ) ? $args['default'] : '' );
 			$args['name']  = $this->generate_field_name( $args['id'] );
 
+			// Create classes from show/hide values.
+			if ( $args['showControlGroup'] && empty( $args['showIfValue'] ) && empty( $args['hideIfValue'] ) ) {
+				$args['class'] .= ' control-group';
+				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= ' control-group__controller';
+			}
+
+			if ( $args['tabControlGroup'] ) {
+				$args['class'] .= ' tab-control-group';
+				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tabControlGroup'] );
+				$args['class'] .= ' tab-control-group__controller';
+			}
+
+			if ( ! empty( $args['showIfValue'] ) && esc_attr( $args['showControlGroup'] ) ) {
+				$class = ' control-group__show-if';
+
+				$args['class'] .= ' control-group';
+				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= $class;
+
+				foreach ( $args['showIfValue'] as $value ) {
+					$args['class'] .= $class . '--' . $value;
+				}
+			}
+
+			if ( ! empty( $args['hideIfValue'] ) && esc_attr( $args['showControlGroup'] ) ) {
+				$class = ' control-group__hide-if';
+
+				$args['class'] .= ' control-group';
+				$args['class'] .= ' control-group--' . esc_attr( $args['showControlGroup'] );
+				$args['class'] .= $class;
+
+				foreach ( $args['hideIfValue'] as $value ) {
+					$args['class'] .= $class . '--' . $value;
+				}
+			}
+
 			do_action( 'wpsf_before_field_' . $this->option_group );
 			do_action( 'wpsf_before_field_' . $this->option_group . '_' . $args['id'] );
 
@@ -917,10 +954,45 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 						continue;
 					}
 
+					if ( ! isset( $tab_data['class'] ) ) {
+						$tab_data['class'] = '';
+					}
+
+					// Create classes from show/hide values.
+					if ( $tab_data['tabControlGroup'] && empty( $tab_data['showIfValue'] ) && empty( $tab_data['hideIfValue'] ) ) {
+						$tab_data['class'] .= ' tab-control-group';
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= ' tab-control-group__controller';
+					}
+
+					if ( ! empty( $tab_data['showIfValue'] ) && esc_attr( $tab_data['tabControlGroup'] ) ) {
+						$class = ' tab-control-group__show-if';
+
+						$tab_data['class'] .= ' tab-control-group';
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= $class;
+
+						foreach ( $tab_data['showIfValue'] as $value ) {
+							$tab_data['class'] .= $class . '--' . $value;
+						}
+					}
+
+					if ( ! empty( $tab_data['hideIfValue'] ) && esc_attr( $tab_data['tabControlGroup'] ) ) {
+						$class = ' tab-control-group__hide-if';
+
+						$tab_data['class'] .= ' tab-control-group';
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tabControlGroup'] );
+						$tab_data['class'] .= $class;
+
+						foreach ( $tab_data['hideIfValue'] as $value ) {
+							$tab_data['class'] .= $class . '--' . $value;
+						}
+					}
+
 					$active = $i == 0 ? 'wpsf-nav__item--active' : '';
 					?>
 					<li class="wpsf-nav__item <?php echo $active; ?>">
-						<a class="wpsf-nav__item-link" href="#tab-<?php echo $tab_data['id']; ?>"><?php echo $tab_data['title']; ?></a>
+						<a class="wpsf-nav__item-link <?php echo esc_attr( $tab_data['class'] ); ?>" href="#tab-<?php echo $tab_data['id']; ?>"><?php echo $tab_data['title']; ?></a>
 					</li>
 					<?php
 					$i ++;

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -365,9 +365,9 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				$args['class'] .= ' control-group__controller';
 			}
 
-			if ( $args['tab_control_group'] ) {
+			if ( $args['tab_controller'] ) {
 				$args['class'] .= ' tab-control-group';
-				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tab_control_group'] );
+				$args['class'] .= ' tab-control-group--' . esc_attr( $args['tab_controller'] );
 				$args['class'] .= ' tab-control-group__controller';
 			}
 
@@ -959,10 +959,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 					}
 
 					// Create classes from show/hide values.
-					if ( $tab_data['tab_controller'] ) {
+					if ( $tab_data['tab_control_group'] ) {
 						$tab_data['class'] .= ' tab-control-group';
-						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_controller'] );
-						$tab_data['class'] .= ' tab-control-group__controller';
+						$tab_data['class'] .= ' tab-control-group--' . esc_attr( $tab_data['tab_control_group'] );
+						// $tab_data['class'] .= ' tab-control-group__controller';
 					}
 
 					if ( ! empty( $tab_data['show_if_value'] ) && esc_attr( $tab_data['tab_control_group'] ) ) {


### PR DESCRIPTION
Fixes #61.

**To show and hide tabs:**

```
$settings['tabs'][] = array(
    'id'              => 'styles',
    'title'           => __( 'Styles', 'flux-checkout' ),
    'tabControlGroup' => 'desktop_enabled',
    // 'showIfValue'     => array( true ), // show if will hide the tab unless the value matches.
    'hideIfValue'     => array( true ), // hide will show the tab unless the value matches.
);
```

On your control, be sure to set the same control name:

```
array(
        'id'              => 'desktop_enabled',
        'title'           => __( 'Enable on Desktop', 'flux-checkout' ),
        'subtitle'        => __( 'Enable or disable Flux Checkout on Desktop.', 'flux-checkout' ),
        'type'            => 'toggle',
        'default'         => true,
        'tabControlGroup' => 'desktop_enabled', // Needs to be set to the same tab control. Does not have to match the Id of this control. 
),
```

**To show and hide controls**

```
array(
        'id'               => 'logo_image',
        'title'            => __( 'Header Image', 'flux-checkout' ),
        'subtitle'         => __( 'Select your logo (Recommended size: 200 x 40px).', 'flux-checkout' ),
        'type'             => 'file',
        'showControlGroup' => 'header',
        'showIfValue'      => array( 'image' ),  // show if will hide the control unless the value matches.
        // 'hideIfValue'      => array( 'text' ),  // hide if will show the control unless the value matches.
),
```

You need to set the control that the values are taken from like this:

```
array(
        'id'               => 'branding',
        'title'            => __( 'Header Type', 'flux-checkout' ),
        'subtitle'         => __( 'Select whether to use an image or text for the branding.', 'flux-checkout' ),
        'type'             => 'select',
        'choices'          => array(
	        'text'  => __( 'Text', 'flux-checkout' ),
	        'image' => __( 'Image', 'flux-checkout' ),
        ),
        'default'          => 'text',
        'class'            => 'header-type',
        'showControlGroup' => 'header', // Needs to be set to the same control. Does not have to match the Id of this control. 
),
```

Demo here: https://cln.sh/Wiwuhw