### PR TITLE
[fix] Show and Hide not working if elements are wrapped in labels

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -298,7 +298,7 @@
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
 				
 				// Field.
-				if ( 'td' === parent_tag ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag ) {
 					element.closest( 'tr' ).hide();
 
 					wpsf.maybe_show_element( element, function() {
@@ -339,7 +339,7 @@
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
 				
 				// Field.
-				if ( 'td' === parent_tag ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {


### PR DESCRIPTION
Fixes show if and hide if conditions for certain elements that are wrapped in labels. 