### PR TITLE
Add code editor field

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Valid `fields` values are:
 * `title` - Field title
 * `desc` - Field description
 * `placeholder` - Field placeholder
-* `type` - Field type (text/password/textarea/select/radio/checkbox/checkboxes/color/file/editor/codeeditor)
+* `type` - Field type (text/password/textarea/select/radio/checkbox/checkboxes/color/file/editor/code_editor)
 * `default` - Default value (or selected option)
 * `choices` - Array of options (for select/radio/checkboxes)
-* `mimetype` - Any valid mime type accepted by Code Mirror for syntax highlighting (for codeeditor)
+* `mimetype` - Any valid mime type accepted by Code Mirror for syntax highlighting (for code_editor)
 
 See `settings/example-settings.php` for an example of possible values.
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,10 @@ Valid `fields` values are:
 * `title` - Field title
 * `desc` - Field description
 * `placeholder` - Field placeholder
-* `type` - Field type (text/password/textarea/select/radio/checkbox/checkboxes/color/file)
+* `type` - Field type (text/password/textarea/select/radio/checkbox/checkboxes/color/file/editor/codeeditor)
 * `default` - Default value (or selected option)
 * `choices` - Array of options (for select/radio/checkboxes)
+* `mimetype` - Any valid mime type accepted by Code Mirror for syntax highlighting (for codeeditor)
 
 See `settings/example-settings.php` for an example of possible values.
 

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -165,11 +165,11 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default' => '',
 			),
 			array(
-				'id'          => 'codeeditor',
+				'id'          => 'code_editor',
 				'title'       => 'Code Editor',
 				'desc'        => 'This is a description.',
 				'placeholder' => 'This is a placeholder.',
-				'type'        => 'codeeditor',
+				'type'        => 'code_editor',
 				'mimetype'    => 'css',
 				'default'     => 'This is default.',
 			),

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -164,6 +164,15 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'    => 'editor',
 				'default' => '',
 			),
+			array(
+				'id'          => 'codeeditor',
+				'title'       => 'Code Editor',
+				'desc'        => 'This is a description.',
+				'placeholder' => 'This is a placeholder.',
+				'type'        => 'codeeditor',
+				'mimetype'    => 'css',
+				'default'     => 'This is default.',
+			),
 		),
 	);
 

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -819,6 +819,29 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		}
 
 		/**
+		 * Generate: Codeeditor field
+		 *
+		 * @param array $args
+		 */
+		public function generate_codeeditor_field( $args ) {
+			$args['value'] = esc_html( esc_attr( $args['value'] ) );
+ 			
+			echo '<textarea name="' . $args['name'] . '" id="' . $args['id'] . '" placeholder="' . $args['placeholder'] . '" rows="5" cols="60" class="' . $args['class'] . '">' . $args['value'] . '</textarea>';
+
+    	$settings = wp_enqueue_code_editor( array( 'type' => $args['mimetype'] ) );
+
+			wp_add_inline_script(
+        'code-editor',
+        sprintf(
+            'jQuery( function() { wp.codeEditor.initialize( "' . $args['id'] . '", %s ); } );',
+            wp_json_encode( $settings )
+        )
+    	);
+
+			$this->generate_description( $args['desc'] );
+		}
+
+		/**
 		 * Generate: Custom field
 		 *
 		 * @param array $args

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -824,16 +824,14 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args
 		 */
 		public function generate_code_editor_field( $args ) {
-			$args['value'] = esc_html( esc_attr( $args['value'] ) );
- 			
-			echo '<textarea name="' . $args['name'] . '" id="' . $args['id'] . '" placeholder="' . $args['placeholder'] . '" rows="5" cols="60" class="' . $args['class'] . '">' . $args['value'] . '</textarea>';
+			printf( '<textarea name="%s" id="%s" placeholder="%s" rows="5" cols="60" class="%s">%s</textarea>', esc_attr( $args['name'] ), esc_attr( $args['id'] ), esc_attr( $args['placeholder'] ), esc_attr( $args['class'] ), esc_html( esc_attr( $args['value'] ) ) );
 
-    	$settings = wp_enqueue_code_editor( array( 'type' => $args['mimetype'] ) );
+    	$settings = wp_enqueue_code_editor( array( 'type' => esc_attr( $args['mimetype'] ) ) );
 
 			wp_add_inline_script(
         'code-editor',
         sprintf(
-            'jQuery( function() { wp.codeEditor.initialize( "' . $args['id'] . '", %s ); } );',
+            'jQuery( function() { wp.codeEditor.initialize( "' . esc_attr( $args['id'] ) . '", %s ); } );',
             wp_json_encode( $settings )
         )
     	);

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -819,11 +819,11 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		}
 
 		/**
-		 * Generate: Codeeditor field
+		 * Generate: Code editor field
 		 *
 		 * @param array $args
 		 */
-		public function generate_codeeditor_field( $args ) {
+		public function generate_code_editor_field( $args ) {
 			$args['value'] = esc_html( esc_attr( $args['value'] ) );
  			
 			echo '<textarea name="' . $args['name'] . '" id="' . $args['id'] . '" placeholder="' . $args['placeholder'] . '" rows="5" cols="60" class="' . $args['class'] . '">' . $args['value'] . '</textarea>';

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -8,11 +8,11 @@
  * @license MIT
  */
 
-if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
+if ( ! class_exists( 'Iconic_WSSV_Settings_Framework' ) ) {
 	/**
 	 * WordPressSettingsFramework class
 	 */
-	class WordPressSettingsFramework {
+	class Iconic_WSSV_Settings_Framework {
 		/**
 		 * @access private
 		 * @var array
@@ -882,17 +882,32 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args
 		 */
 		public function generate_code_editor_field( $args ) {
-			printf( '<textarea name="%s" id="%s" placeholder="%s" rows="5" cols="60" class="%s">%s</textarea>', esc_attr( $args['name'] ), esc_attr( $args['id'] ), esc_attr( $args['placeholder'] ), esc_attr( $args['class'] ), esc_html( esc_attr( $args['value'] ) ) );
+			printf(
+				'<textarea
+					name="%s"
+					id="%s"
+					placeholder="%s"
+					rows="5"
+					cols="60"
+					class="%s"
+				>%s</textarea>', 
+				esc_attr( $args['name'] ),
+				esc_attr( $args['id'] ),
+				esc_attr( $args['placeholder'] ),
+				esc_attr( $args['class'] ),
+				esc_html( $args['value'] ) 
+			);
 
-    	$settings = wp_enqueue_code_editor( array( 'type' => esc_attr( $args['mimetype'] ) ) );
+    		$settings = wp_enqueue_code_editor( array( 'type' => esc_attr( $args['mimetype'] ) ) );
 
 			wp_add_inline_script(
-        'code-editor',
-        sprintf(
-            'jQuery( function() { wp.codeEditor.initialize( "' . esc_attr( $args['id'] ) . '", %s ); } );',
-            wp_json_encode( $settings )
-        )
-    	);
+				'code-editor',
+				sprintf(
+					'jQuery( function() { wp.codeEditor.initialize( "%s", %s ); } );',
+					esc_attr( $args['id'] ),
+					wp_json_encode( $settings )
+				)
+			);
 
 			$this->generate_description( $args['desc'] );
 		}


### PR DESCRIPTION
Added support for a code editor field using WordPress's CodeMirror editor.

Supplying the 'mimetype' argument when creating the field will let you select the syntax highlighting used for the editor.

```php
array(
  'id'          => 'codeeditor',
  'title'       => 'Code Editor',
  'desc'        => 'This is a description.',
  'placeholder' => 'This is a placeholder.',
  'type'        => 'codeeditor',
  'mimetype'    => 'css',
  'default'     => 'This is default.',
)
```