### PR TITLE
[fix] Parenthesized conditionals in ternaries to prevent PHP 8.1 fatals.

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -324,26 +324,26 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 									$tooltip     = '';
 
 									if ( isset( $field['link'] ) && is_array( $field['link'] ) ) {
-										$link_url      = isset( $field['link']['url'] ) ? esc_html( $field['link']['url'] ) : '';
-										$link_text     = isset( $field['link']['text'] ) ? esc_html( $field['link']['text'] ) : __( 'Learn More' );
-										$link_external = isset( $field['link']['external'] ) ? (bool) $field['link']['external'] : true;
-										$link_type     = isset( $field['link']['type'] ) ? esc_attr( $field['link']['type'] ) : 'tooltip';
-										$link_target   = $link_external ? ' target="_blank"' : '';
+										$link_url      = ( isset( $field['link']['url'] ) ) ? esc_html( $field['link']['url'] ) : '';
+										$link_text     = ( isset( $field['link']['text'] ) ) ? esc_html( $field['link']['text'] ) : __( 'Learn More' );
+										$link_external = ( isset( $field['link']['external'] ) ) ? (bool) $field['link']['external'] : true;
+										$link_type     = ( isset( $field['link']['type'] ) ) ? esc_attr( $field['link']['type'] ) : 'tooltip';
+										$link_target   = ( $link_external ) ? ' target="_blank"' : '';
 
 										if ( 'tooltip' === $link_type ) {
 											$link_text = sprintf( '<i class="dashicons dashicons-info wpsf-link-icon" title="%s"><span class="screen-reader-text">%s</span></i>', $link_text, $link_text );
 										}
 
-										$link = $link_url ? sprintf( '<a class="wpsf-link" href="%s"%s>%s</a>', $link_url, $link_target, $link_text ) : '';
+										$link = ( $link_url ) ? sprintf( '<a class="wpsf-link" href="%s"%s>%s</a>', $link_url, $link_target, $link_text ) : '';
 										
 										if ( $link && 'tooltip' === $link_type ) {
 											$tooltip = $link;
 										} elseif ( $link ) {
-											$field['subtitle'] .= empty( $field['subtitle'] ) ? $link : sprintf( '<br/><br/>%s', $link );
+											$field['subtitle'] .= ( empty( $field['subtitle'] ) ) ? $link : sprintf( '<br/><br/>%s', $link );
 										}
 									}
 
-									$title = ! empty( $field['subtitle'] ) ? sprintf( '%s %s<span class="wpsf-subtitle">%s</span>', $field['title'], $tooltip, $field['subtitle'] ) : sprintf( '%s %s', $field['title'], $tooltip );
+									$title = ( ! empty( $field['subtitle'] ) ) ? sprintf( '%s %s<span class="wpsf-subtitle">%s</span>', $field['title'], $tooltip, $field['subtitle'] ) : sprintf( '%s %s', $field['title'], $tooltip );
 
 									add_settings_field(
 										$field['id'],
@@ -377,7 +377,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				return 0;
 			}
 
-			return $a['section_order'] > $b['section_order'] ? 1 : 0;
+			return ( $a['section_order'] > $b['section_order'] ) ? 1 : 0;
 		}
 
 		/**
@@ -393,8 +393,8 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			$options = get_option( $this->option_group . '_settings' );
 
-			$args['id']    = $this->has_tabs() ? sprintf( '%s_%s_%s', $section['tab_id'], $section['section_id'], $args['id'] ) : sprintf( '%s_%s', $section['section_id'], $args['id'] );
-			$args['value'] = isset( $options[ $args['id'] ] ) ? $options[ $args['id'] ] : ( isset( $args['default'] ) ? $args['default'] : '' );
+			$args['id']    = ( $this->has_tabs() ) ? sprintf( '%s_%s_%s', $section['tab_id'], $section['section_id'], $args['id'] ) : sprintf( '%s_%s', $section['section_id'], $args['id'] );
+			$args['value'] = ( isset( $options[ $args['id'] ] ) ) ? $options[ $args['id'] ] : ( isset( $args['default'] ) ? $args['default'] : '' );
 			$args['name']  = $this->generate_field_name( $args['id'] );
 
 			$args['class'] .= self::add_show_hide_classes( $args );
@@ -466,7 +466,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_time_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			$timepicker = ! empty( $args['timepicker'] ) ? htmlentities( json_encode( $args['timepicker'] ) ) : null;
+			$timepicker = ( ! empty( $args['timepicker'] ) ) ? htmlentities( json_encode( $args['timepicker'] ) ) : null;
 
 			echo '<input type="text" name="' . $args['name'] . '" id="' . $args['id'] . '" value="' . $args['value'] . '" class="timepicker regular-text ' . $args['class'] . '" data-timepicker="' . $timepicker . '" />';
 
@@ -481,7 +481,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_date_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			$datepicker = ! empty( $args['datepicker'] ) ? htmlentities( json_encode( $args['datepicker'] ) ) : null;
+			$datepicker = ( ! empty( $args['datepicker'] ) ) ? htmlentities( json_encode( $args['datepicker'] ) ) : null;
 
 			echo '<input type="text" name="' . $args['name'] . '" id="' . $args['id'] . '" value="' . $args['value'] . '" class="datepicker regular-text ' . $args['class'] . '" data-datepicker="' . $datepicker . '" />';
 
@@ -497,7 +497,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_group_field( $args ) {
 			$value     = (array) $args['value'];
-			$row_count = ! empty( $value ) ? count( $value ) : 1;
+			$row_count = ( ! empty( $value ) ) ? count( $value ) : 1;
 
 			echo '<table class="widefat wpsf-group" cellspacing="0">';
 
@@ -527,11 +527,11 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_group_row_template( $args, $blank = false, $row = 0 ) {
 			$row_template = false;
-			$row_id       = ! empty( $args['value'][ $row ]['row_id'] ) ? $args['value'][ $row ]['row_id'] : $row;
-			$row_id_value = $blank ? '' : $row_id;
+			$row_id       = ( ! empty( $args['value'][ $row ]['row_id'] ) ) ? $args['value'][ $row ]['row_id'] : $row;
+			$row_id_value = ( $blank ) ? '' : $row_id;
 
 			if ( $args['subfields'] ) {
-				$row_class = $row % 2 == 0 ? 'alternate' : '';
+				$row_class = ( $row % 2 == 0 ) ? 'alternate' : '';
 
 				$row_template .= sprintf( '<tr class="wpsf-group__row %s">', $row_class );
 
@@ -589,14 +589,14 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				if ( is_array( $text ) ) {
 					echo sprintf( '<optgroup label="%s">', esc_html( $value ) );
 					foreach ( $text as $group_value => $group_text ) {
-						$selected = $group_value === $args['value'] ? 'selected="selected"' : '';
+						$selected = ( $group_value === $args['value'] ) ? 'selected="selected"' : '';
 						echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $group_value ), esc_html( $selected ), esc_html( $group_text ) );
 					}
 					echo '</optgroup>';
 					continue;
 				}
 
-				$selected = strval( $value ) === $args['value'] ? 'selected="selected"' : '';
+				$selected = ( strval( $value ) === $args['value'] ) ? 'selected="selected"' : '';
 
 				echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $value ), esc_html( $selected ), esc_html( $text ) );
 			}
@@ -642,7 +642,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			foreach ( $args['choices'] as $value => $text ) {
 				$field_id = sprintf( '%s_%s', $args['id'], $value );
-				$checked  = $value == $args['value'] ? 'checked="checked"' : '';
+				$checked  = ( $value == $args['value'] ) ? 'checked="checked"' : '';
 
 				echo sprintf( '<label><input type="radio" name="%s" id="%s" value="%s" class="%s" %s> %s</label><br />', $args['name'], $field_id, $value, $args['class'], $checked, $text );
 			}
@@ -657,7 +657,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_checkbox_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
-			$checked       = $args['value'] ? 'checked="checked"' : '';
+			$checked       = ( $args['value'] ) ? 'checked="checked"' : '';
 
 			echo '<input type="hidden" name="' . $args['name'] . '" value="0" />';
 			echo '<label><input type="checkbox" name="' . $args['name'] . '" id="' . $args['id'] . '" value="1" class="' . $args['class'] . '" ' . $checked . '> ' . $args['desc'] . '</label>';
@@ -670,7 +670,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_toggle_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
-			$checked       = $args['value'] ? 'checked="checked"' : '';
+			$checked       = ( $args['value'] ) ? 'checked="checked"' : '';
 
 			echo '<input type="hidden" name="' . $args['name'] . '" value="0" />';
 			echo '<label class="switch"><input type="checkbox" name="' . $args['name'] . '" id="' . $args['id'] . '" value="1" class="' . $args['class'] . '" ' . $checked . '> ' . $args['desc'] . '<span class="slider"></span></label>';
@@ -687,7 +687,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			echo '<ul class="wpsf-list wpsf-list--checkboxes">';
 
 			foreach ( $args['choices'] as $value => $text ) {
-				$checked  = is_array( $args['value'] ) && in_array( strval( $value ), array_map( 'strval', $args['value'] ), true ) ? 'checked="checked"' : '';
+				$checked  = ( is_array( $args['value'] ) && in_array( strval( $value ), array_map( 'strval', $args['value'] ), true ) ) ? 'checked="checked"' : '';
 				$field_id = sprintf( '%s_%s', $args['id'], $value );
 
 				echo sprintf( '<li><label><input type="checkbox" name="%s[]" id="%s" value="%s" class="%s" %s> %s</label></li>', $args['name'], $field_id, $value, $args['class'], $checked, $text );
@@ -829,7 +829,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				return;
 			}
 
-			echo isset( $args['output'] ) ? $args['output'] : $args['default'];
+			echo ( isset( $args['output'] ) ) ? $args['output'] : $args['default'];
 		}
 
 		/**
@@ -933,7 +933,7 @@ endwhile;
 						$field['default'] = array_values( $field['default'] );
 					}
 
-					$setting_key = $this->has_tabs() ? sprintf( '%s_%s_%s', $section['tab_id'], $section['section_id'], $field['id'] ) : sprintf( '%s_%s', $section['section_id'], $field['id'] );
+					$setting_key = ( $this->has_tabs() ) ? sprintf( '%s_%s_%s', $section['tab_id'], $section['section_id'], $field['id'] ) : sprintf( '%s_%s', $section['section_id'], $field['id'] );
 
 					if ( isset( $saved_settings[ $setting_key ] ) ) {
 						$settings[ $settings_name ][ $setting_key ] = $saved_settings[ $setting_key ];
@@ -1003,7 +1003,7 @@ endwhile;
 
 					$tab_data['class'] .= self::add_show_hide_classes( $tab_data );
 
-					$active = $i == 0 ? 'wpsf-nav__item--active' : '';
+					$active = ( $i == 0 ) ? 'wpsf-nav__item--active' : '';
 					?>
 					<li class="wpsf-nav__item <?php echo $active; ?>">
 						<a class="wpsf-nav__item-link <?php echo esc_attr( $tab_data['class'] ); ?>" href="#tab-<?php echo $tab_data['id']; ?>"><?php echo $tab_data['title']; ?></a>


### PR DESCRIPTION
As reported [here](https://github.com/iconicwp/iconic-woothumbs/issues/114), PHP `8.1` fatals when the condition of a nested ternary is not parenthesized.

This PR parenthesizes all of the offending instances, as well as parenthesizing all of the ternary conditions for consistency. I've self-reviewed my changes and tested, but need a 2nd pair of 👀 to check the changes and test WooThumbs on `8.1`

Once merged, we can update deps for all products and roll out point releases next week or sooner. 🎉 