### PR TITLE
Switched out translation functions and added textdomains.

### DIFF
--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -340,15 +340,15 @@ function wpsf_tabbed_settings( $wpsf_settings ) {
 	$wpsf_settings['tabs'] = array(
 		array(
 			'id'    => 'tab_1',
-			'title' => __( 'Tab 1' ),
+			'title' => esc_html__( 'Tab 1', 'text-domain' ),
 		),
 		array(
 			'id'    => 'tab_2',
-			'title' => __( 'Tab 2' ),
+			'title' => esc_html__( 'Tab 2', 'text-domain' ),
 		),
 		array(
 			'id'                => 'tab_3',
-			'title'             => __( 'Tab 3' ),
+			'title'             => esc_html__( 'Tab 3', 'text-domain' ),
 			'tab_control_group' => 'tab-control',
 			'show_if'           => array( // Field will only show if the control `tab_2_section_2_tab-control` is set to true.
 				array(

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -133,7 +133,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$this->settings_wrapper = apply_filters( 'wpsf_register_settings_' . $this->option_group, array() );
 
 			if ( ! is_array( $this->settings_wrapper ) ) {
-				return new WP_Error( 'broke', __( 'WPSF settings must be an array' ) );
+				return new WP_Error( 'broke', esc_html__( 'WPSF settings must be an array', 'wp-sf' ) );
 			}
 
 			// If "sections" is set, this settings group probably has tabs
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 		public function settings_page_content() {
 			if ( ! current_user_can( $this->settings_page['capability'] ) ) {
-				wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
+				wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-sf' ) );
 			}
 			?>
 			<div class="wpsf-settings wpsf-settings--<?php echo esc_attr( $this->option_group ); ?>">
@@ -261,9 +261,9 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			wp_enqueue_script( 'wpsf' );
 
 			$data = array(
-				'select_file'          => __( 'Please select a file to import' ),
-				'invalid_file'         => __( 'Invalid file' ),
-				'something_went_wrong' => __( 'Something went wrong' ),
+				'select_file'          => esc_html__( 'Please select a file to import', 'wp-sf' ),
+				'invalid_file'         => esc_html__( 'Invalid file', 'wp-sf' ),
+				'something_went_wrong' => esc_html__( 'Something went wrong', 'wp-sf' ),
 			);
 			wp_localize_script( 'wpsf', 'wpsf_vars', $data );
 
@@ -335,7 +335,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 									if ( isset( $field['link'] ) && is_array( $field['link'] ) ) {
 										$link_url      = ( isset( $field['link']['url'] ) ) ? esc_html( $field['link']['url'] ) : '';
-										$link_text     = ( isset( $field['link']['text'] ) ) ? esc_html( $field['link']['text'] ) : __( 'Learn More' );
+										$link_text     = ( isset( $field['link']['text'] ) ) ? esc_html( $field['link']['text'] ) : esc_html__( 'Learn More', 'wp-sf' );
 										$link_external = ( isset( $field['link']['external'] ) ) ? (bool) $field['link']['external'] : true;
 										$link_type     = ( isset( $field['link']['type'] ) ) ? esc_attr( $field['link']['type'] ) : 'tooltip';
 										$link_target   = ( $link_external ) ? ' target="_blank"' : '';
@@ -505,7 +505,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_export_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
-			$args['value'] = empty( $args['value'] ) ? __( 'Export Settings' ) : $args['value'];
+			$args['value'] = empty( $args['value'] ) ? esc_html__( 'Export Settings', 'wp-sf' ) : $args['value'];
 			$option_group  = $this->option_group;
 			$export_url    = site_url() . '/wp-admin/admin-ajax.php?action=wpsf_export_settings&_wpnonce=' . wp_create_nonce( 'wpsf_export_settings' ) . '&option_group=' . $option_group;
 
@@ -522,7 +522,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_import_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
-			$args['value'] = empty( $args['value'] ) ? __( 'Import Settings' ) : $args['value'];
+			$args['value'] = empty( $args['value'] ) ? esc_html__( 'Import Settings', 'wp-sf' ) : $args['value'];
 			$option_group  = $this->option_group;
 
 			echo sprintf(
@@ -831,9 +831,9 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 						// Create the media frame.
 						file_frame = wp.media.frames.file_frame = wp.media({
-							title: '<?php echo __( 'Select a image to upload' ); ?>',
+							title: '<?php echo esc_html__( 'Select a image to upload', 'wp-sf' ); ?>',
 							button: {
-								text: '<?php echo __( 'Use this image' ); ?>',
+								text: '<?php echo esc_html__( 'Use this image', 'wp-sf' ); ?>',
 							},
 							multiple: false	// Set to true to allow multiple files to be selected
 						});
@@ -1183,11 +1183,11 @@ endwhile;
 			$option_group = filter_input( INPUT_GET, 'option_group' );
 
 			if ( empty( $_wpnonce ) || ! wp_verify_nonce( $_wpnonce, 'wpsf_export_settings' ) ) {
-				wp_die( esc_html__( 'Action failed.' ) );
+				wp_die( esc_html__( 'Action failed.', 'wp-sf' ) );
 			}
 
 			if ( empty( $option_group ) ) {
-				wp_die( esc_html__( 'No option group specified.' ) );
+				wp_die( esc_html__( 'No option group specified.', 'wp-sf' ) );
 			}
 
 			$options = get_option( $option_group . '_settings' );

--- a/wpsf-test.php
+++ b/wpsf-test.php
@@ -41,8 +41,8 @@ class WPSFTest {
 	public function add_settings_page() {
 		$this->wpsf->add_settings_page( array(
 			'parent_slug' => 'woocommerce',
-			'page_title'  => __( 'Page Title', 'text-domain' ),
-			'menu_title'  => __( 'menu Title', 'text-domain' ),
+			'page_title'  => esc_html__( 'Page Title', 'text-domain' ),
+			'menu_title'  => esc_html__( 'menu Title', 'text-domain' ),
 			'capability'  => 'manage_woocommerce',
 		) );
 	}


### PR DESCRIPTION
Replaced instances of `__()` with the safer `esc_html__()` and added textdomains where required.

I felt `wpsf` was too generic, preferring the hypenated `wp-sf` to avoid textdomain conflicts.