### PR TITLE
Fix wpsf being initialized before document loads

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -575,6 +575,6 @@
 		}
 	};
 
-	$( document ).ready( wpsf.on_ready() );
+	$( document ).ready( wpsf.on_ready );
 
 }( jQuery, document ));


### PR DESCRIPTION
Because of the parentheses on the wpsf.on_ready function signature, it is being called immediately instead of waiting until the document is ready.
This causes some undesirable effects (such as tabs not being cached and handlers not being registered).