### PR TITLE
[fix] File button overflow issue

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -531,10 +531,6 @@ p.submit {
 	margin: 15px 0 0;
 }
 
-.wpsf-import {
-    overflow: hidden;
-}
-
 .wpsf-import__false_btn {
 	position: relative;
 	overflow: hidden;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -531,6 +531,16 @@ p.submit {
 	margin: 15px 0 0;
 }
 
+.wpsf-import {
+    overflow: hidden;
+}
+
+.wpsf-import__false_btn {
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+}
+
 .wpsf-import input[type=file] {
     position: absolute;
     font-size: 100px;


### PR DESCRIPTION
Add import and export fields like this:

```
                    'fields'              => array(
			array(
				'id'          => 'import',
				'title'       => __( 'Import', 'jckwds' ),
				'subtitle'    => __( 'Import settings', 'jckwds' ),
				'type'        => 'import',
			),
			array(
				'id'          => 'export',
				'title'       => __( 'Export', 'jckwds' ),
				'subtitle'    => __( 'Export settings', 'jckwds' ),
				'type'        => 'export',
			),
		),
```

Notice that clicking on the `Export` button does not work because the hidden <input type=file> button overlaps with the export button. This PR fixes that issue. 

Video demonstrating the problem:

https://user-images.githubusercontent.com/5794565/154633935-85bb5944-011b-4c7d-a863-9ec748917ce4.mp4


