### PR TITLE
[fix] Replace () with call_user_func()

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -883,7 +883,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_custom_field( $args ) {
 			if ( isset( $args['output'] ) && is_callable( $args['output'] ) ) {
-				$args['output']( $args );
+				call_user_func( $args['output'], $args );
 				return;
 			}
 


### PR DESCRIPTION
This syntax would trigger a malware warning:

```
$args['output']( $args );
```

So we replace it with 'call_user_func'. 

**Steps to Test**
1. Checkout to this branch of flux checkout: https://github.com/iconicwp/flux-checkout/pull/130. We are picking this branch because it uses the 'custom' field type of setting framework to create the swatches field.
2. Run `npm update && composer update && gulp deps`
3. Go to the Flux setting in the dashboard, ensure all fields are working fine, especially the color swatches 
![image](https://user-images.githubusercontent.com/5794565/155492218-2a5097db-6a6b-4671-8465-c39fc2897170.png)
