### PR TITLE
[update] Improve import field

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -538,9 +538,7 @@ p.submit {
 }
 
 .wpsf-import input[type=file] {
-    position: absolute;
-    font-size: 100px;
-    opacity: 0;
+    display: none;
 }
 
 .wpsf-import__file {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -502,6 +502,11 @@
 		 */
 		importer: {
 			init: function () {
+
+				$( '.wpsf-import__button' ).click( function () {
+					$( this ).parent().find( '.wpsf-import__file_field' ).trigger( 'click' );
+				} );
+
 				$( ".wpsf-import__file_field" ).change( function ( e ) {
 					$this = $( this );
 					$td = $this.closest( 'td' );


### PR DESCRIPTION
@jamesckemp Based on your feedback on this PR: https://github.com/iconicwp/iconic-woo-delivery-slots/pull/234

> Can we change this slightly? I don't think we need the input field to be there transparent. it means the hover state doesn't work on the button.
Instead, could we just run jQuery( '#advance_importexport_import' ).click() when the button is clicked?