### PR TITLE
[update] Added new argument for the 'editor' field:- `editor_settings` to pass the custom settings arguments to wp_editor()

### DIFF
--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -193,11 +193,14 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default' => '',
 			),
 			array(
-				'id'      => 'editor',
-				'title'   => 'Editor',
-				'desc'    => 'This is a description.',
-				'type'    => 'editor',
-				'default' => '',
+				'id'              => 'editor',
+				'title'           => 'Editor',
+				'desc'            => 'This is a description.',
+				'type'            => 'editor',
+				'default'         => '',
+				'editor_settings' => array(
+					'teeny' => false,
+				),
 			),
 			array(
 				'id'          => 'code_editor',

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -1097,7 +1097,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args Field arguments.
 		 */
 		public function generate_editor_field( $args ) {
-			wp_editor( $args['value'], $args['id'], array( 'textarea_name' => $args['name'] ) );
+			$settings                  = ( isset( $args['editor_settings'] ) && is_array( $args['editor_settings'] ) ) ? $args['editor_settings'] : array();
+			$settings['textarea_name'] = $args['name'];
+
+			wp_editor( $args['value'], $args['id'], $settings );
 
 			$this->generate_description( $args['desc'] );
 		}


### PR DESCRIPTION
The newly added `editor_settings` argument will let you pass any of [these arguments](https://developer.wordpress.org/reference/functions/wp_editor/) to the wp_editor, which is called when `editor` field is used. 

<img width="1179" alt="image" src="https://user-images.githubusercontent.com/5794565/196892568-7a87cb2e-71f0-4e4a-8863-a1fafa0a0101.png">

To test, edit the `editor` field in the example-settings.php, and pass in any of the above displayed arguments. 
