### PR TITLE
[fix] Show/hide logic now works for the visual field

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -349,11 +349,12 @@
 			$( '.show-if' ).each( function( index ) {
 				var element = $( this ),
 				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase(),
-				    visual_field_parent_class = 'wpsf-visual-field__item-footer';
+				    visual_field_parent_class = 'wpsf-visual-field__item-footer',
+				    is_visual_field = element.parent().hasClass( visual_field_parent_class );
 				
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( visual_field_parent_class ) ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || is_visual_field ) {
 					element.closest( 'tr' ).hide();
 
 					wpsf.maybe_show_element( element, function() {
@@ -371,7 +372,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! element.parent().hasClass( visual_field_parent_class ) ) {
+				if ( 'div' === parent_tag && ! is_visual_field ) {
 					element.prev().hide();
 					element.next().hide();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
@@ -394,7 +395,7 @@
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( visual_field_parent_class ) ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || is_visual_field ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {
@@ -412,7 +413,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! element.parent().hasClass( visual_field_parent_class ) ) {
+				if ( 'div' === parent_tag && ! is_visual_field ) {
 					element.prev().show();
 					element.next().show();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -349,9 +349,9 @@
 			$( '.show-if' ).each( function( index ) {
 				var element = $( this );
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
-				
+
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
 					element.closest( 'tr' ).hide();
 
 					wpsf.maybe_show_element( element, function() {
@@ -369,7 +369,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag ) {
+				if ( 'div' === parent_tag && ! element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
 					element.prev().hide();
 					element.next().hide();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
@@ -390,9 +390,9 @@
 			$( '.hide-if' ).each( function( index ) {
 				var element = $( this );
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
-				
+
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {
@@ -410,7 +410,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag ) {
+				if ( 'div' === parent_tag && ! element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
 					element.prev().show();
 					element.next().show();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -347,11 +347,13 @@
 		control_groups: function() {
 			// If show if, hide by default.
 			$( '.show-if' ).each( function( index ) {
-				var element = $( this );
-				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
+				var element = $( this ),
+				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase(),
+				    visual_field_parent_class = 'wpsf-visual-field__item-footer';
+				
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( visual_field_parent_class ) ) {
 					element.closest( 'tr' ).hide();
 
 					wpsf.maybe_show_element( element, function() {
@@ -369,7 +371,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
+				if ( 'div' === parent_tag && ! element.parent().hasClass( visual_field_parent_class ) ) {
 					element.prev().hide();
 					element.next().hide();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
@@ -392,7 +394,7 @@
 				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || element.parent().hasClass( visual_field_parent_class ) ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {
@@ -410,7 +412,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! element.parent().hasClass( 'wpsf-visual-field__item-footer' ) ) {
+				if ( 'div' === parent_tag && ! element.parent().hasClass( visual_field_parent_class ) ) {
 					element.prev().show();
 					element.next().show();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -348,13 +348,11 @@
 			// If show if, hide by default.
 			$( '.show-if' ).each( function( index ) {
 				var element = $( this ),
-				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase(),
-				    visual_field_parent_class = 'wpsf-visual-field__item-footer',
-				    is_visual_field = element.parent().hasClass( visual_field_parent_class );
+				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase();
 				
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || is_visual_field ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || wpsf.is_visual_field( element ) ) {
 					element.closest( 'tr' ).hide();
 
 					wpsf.maybe_show_element( element, function() {
@@ -372,7 +370,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! is_visual_field ) {
+				if ( 'div' === parent_tag && ! wpsf.is_visual_field( element ) ) {
 					element.prev().hide();
 					element.next().hide();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
@@ -391,11 +389,11 @@
 
 			// If hide if, show by default.
 			$( '.hide-if' ).each( function( index ) {
-				var element = $( this );
-				var parent_tag = element.parent().prop( 'nodeName' ).toLowerCase()
+				var element = $( this ),
+				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase();
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || is_visual_field ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || wpsf.is_visual_field( element ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {
@@ -413,7 +411,7 @@
 				}
 
 				// Section.
-				if ( 'div' === parent_tag && ! is_visual_field ) {
+				if ( 'div' === parent_tag && ! wpsf.is_visual_field( element ) ) {
 					element.prev().show();
 					element.next().show();
 					if ( element.next().hasClass( 'wpsf-section-description' ) ) {
@@ -429,6 +427,15 @@
 					} );
 				}
 			} );
+		},
+		
+		/**
+		 * Is the element part of a visual field?
+		 * 
+		 * @param {object} element Element.
+		 */
+		is_visual_field: function( element ) {
+			return element.parent().hasClass( 'wpsf-visual-field__item-footer' );
 		},
 
 		/**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -393,7 +393,7 @@
 				    parent_tag = element.parent().prop( 'nodeName' ).toLowerCase();
 
 				// Field.
-				if ( 'td' === parent_tag || 'label' === parent_tag || wpsf.is_visual_field( element ) {
+				if ( 'td' === parent_tag || 'label' === parent_tag || wpsf.is_visual_field( element ) ) {
 					element.closest( 'tr' ).show();
 
 					wpsf.maybe_hide_element( element, function() {


### PR DESCRIPTION
While developing a feature I discovered that the Visual field does not work with the show_if/hide_if conditional logic.

This was down to the fact that the parent element of the Visual field's input is a `div`, meaning that the `Section` logic was firing.

I've updated the logic to ensure this now works as it should.