### PR TITLE
add autocomplete attribute to args list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
             "email": "me@jckemp.com"
         }
     ],
-    "require": {
+    "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0"
     }
 }

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -68,15 +68,16 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @var array
 		 */
 		protected $setting_defaults = array(
-			'id'          => 'default_field',
-			'title'       => 'Default Field',
-			'desc'        => '',
-			'std'         => '',
-			'type'        => 'text',
-			'placeholder' => '',
-			'choices'     => array(),
-			'class'       => '',
-			'subfields'   => array(),
+			'id'           => 'default_field',
+			'title'        => 'Default Field',
+			'desc'         => '',
+			'std'          => '',
+			'type'         => 'text',
+			'placeholder'  => '',
+			'choices'      => array(),
+			'class'        => '',
+			'subfields'    => array(),
+			'autocomplete' => '',
 		);
 
 		/**
@@ -904,7 +905,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_password_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			echo '<input type="password" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" />';
+			echo '<input type="password" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" autocomplete="' . esc_attr( $args['autocomplete'] ) . '"/>';
 
 			$this->generate_description( $args['desc'] );
 		}


### PR DESCRIPTION
Not having an autocomplete attribute can cause the browser to fill in the password field with one saved for the current website which is not what you would want.

Also, dev tools would scream at you: https://www.chromium.org/developers/design-documents/create-amazing-password-forms/#use-autocomplete-attributes