### PR TITLE
[new] Allow multiple values to be selected in dropdown

### DIFF
--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -133,12 +133,13 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default'     => 'This is default',
 			),
 			array(
-				'id'      => 'select',
-				'title'   => 'Select',
-				'desc'    => 'This is a description.',
-				'type'    => 'select',
-				'default' => 'green',
-				'choices' => array(
+				'id'       => 'select',
+				'title'    => 'Select',
+				'desc'     => 'This is a description.',
+				'type'     => 'select',
+				'default'  => 'green',
+				'multiple' => false, // Can be 'true'.
+				'choices'  => array(
 					'red'   => 'Red',
 					'green' => 'Green',
 					'blue'  => 'Blue',

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -871,23 +871,30 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args Field rguments.
 		 */
 		public function generate_select_field( $args ) {
-			$args['value'] = esc_html( esc_attr( $args['value'] ) );
+			$is_multiple = isset( $args['multiple'] ) && filter_var( $args['multiple'], FILTER_VALIDATE_BOOLEAN );
+			$multiple    = $is_multiple ? ' multiple="true" ' : ' ';
 
-			echo '<select name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '">';
+			if ( $is_multiple ) {
+				$args['name'] .= '[]';
+			}
+
+			$values = (array) $args['value'];
+			$values = array_map( 'strval', $values );
+
+			echo '<select ' . esc_html( $multiple ) . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '" >';
 
 			foreach ( $args['choices'] as $value => $text ) {
 				if ( is_array( $text ) ) {
 					echo sprintf( '<optgroup label="%s">', esc_html( $value ) );
 					foreach ( $text as $group_value => $group_text ) {
-						$selected = ( $group_value === $args['value'] ) ? 'selected="selected"' : '';
+						$selected = in_array( (string) $group_value, $values, true ) ? ' selected="selected" ' : '';
 						echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $group_value ), esc_html( $selected ), esc_html( $group_text ) );
 					}
 					echo '</optgroup>';
 					continue;
 				}
 
-				$selected = ( strval( $value ) === $args['value'] ) ? 'selected="selected"' : '';
-
+				$selected = in_array( (string) $value, $values, true ) ? ' selected="selected" ' : '';
 				echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $value ), esc_html( $selected ), esc_html( $text ) );
 			}
 


### PR DESCRIPTION
With this update, you can pass `multiple => true` to make the dropdown field `multiple` selectable (as shown [here](https://github.com/iconicwp/WordPress-Settings-Framework/pull/100/files#diff-83361c8ba99901a412785c2ea00da92b1a318d05afa7cf30a3e5bdd88553e6e7R141)). 

![image](https://user-images.githubusercontent.com/5794565/224696465-54ee35d2-943e-46ca-b374-69bf297e6dca.png)

Using this we can call $('#general_general_select').select2() and create a combo box. 