### PR TITLE
[new] Fire custom event when a group row is added

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -240,6 +240,8 @@
 				wpsf.reindex_group( $group );
 
 				wpsf.trigger_dynamic_fields();
+				
+				$row.trigger('wpsfGroupRowAdded', [$row]);
 
 				return false;
 


### PR DESCRIPTION
https://github.com/iconicwp/WordPress-Settings-Framework/pull/100 brought Select2 support, but this wouldn't work when adding a new row in group, as it stands right now.

It might not be best to leave the task for the framework to check each group element to see if its a select field with `multiple` set, there's no need for it to do that. It can simply fire a custom trigger every time a row is added. Then in the main plugin/theme code, we can listen for that run Select2 on the respective element:

```
$(document).on("wpsfGroupRowAdded", function () {
   $(".select-multiple").each(function () { //select-multiple is class added in field setting array
      if (!$(this).hasClass(".select2-hidden-accessible")) {
        $(this).selectWoo();
      }
    });)
});
```
