### PR TITLE
[fix] Enqueue media script to be able to use media upload feature

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -324,6 +324,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			wp_enqueue_script( 'jquery' );
 			wp_enqueue_script( 'farbtastic' );
+			wp_enqueue_media();
 			wp_enqueue_script( 'media-upload' );
 			wp_enqueue_script( 'thickbox' );
 			wp_enqueue_script( 'jquery-ui-core' );


### PR DESCRIPTION
Without this a settings page with only the media uploading feature does not work

<img width="657" alt="image" src="https://user-images.githubusercontent.com/10324144/233858808-b3c4805b-1317-46bc-addb-76d88f5d0ee5.png">

<img width="550" alt="image" src="https://user-images.githubusercontent.com/10324144/233858825-4444768d-9944-44a6-ad2c-8062dd287acb.png">
