### PR TITLE
Silence errors when there are no settings defined

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -1339,6 +1339,10 @@ endwhile;
 			$saved_settings             = get_option( $this->option_group . '_settings' );
 			$settings[ $settings_name ] = array();
 
+			if ( ! $this->settings ) {
+				return $settings[ $settings_name ];
+			}
+			
 			foreach ( $this->settings as $section ) {
 				if ( empty( $section['fields'] ) ) {
 					continue;

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -187,6 +187,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args Settings page arguments.
 		 */
 		public function add_settings_page( $args ) {
+			if ( ! $this->settings_page ) {
+				return;
+			}
+			
 			$defaults = array(
 				'parent_slug' => false,
 				'page_slug'   => '',


### PR DESCRIPTION
When you have a new project, and no settings have been defined, multiple errors are generated.

This PR returns an empty array if `$this->settings` or `$this->settings_page` are empty, avoiding these errors.  