### PR TITLE
Several fixes and updates

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -690,4 +690,7 @@
 
 	$( document ).ready( wpsf.on_ready );
 
+	// Expose WPSF methods for use elsewhere.
+	window.wpsf = wpsf;
+
 }( jQuery, document ));

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -326,7 +326,7 @@
 					$( this ).addClass( 'alternate' );
 				}
 
-				$( this ).find( "input" ).each( function() {
+				$( this ).find( 'input, select' ).each( function() {
 					var this_input = this,
 						name = jQuery( this ).attr( 'name' );
 

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -894,7 +894,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$values = (array) $args['value'];
 			$values = array_map( 'strval', $values );
 
-			echo '<select ' . esc_html( $multiple ) . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
+			echo '<select ' . esc_html( $multiple ) . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '>';
 
 			foreach ( $args['choices'] as $value => $text ) {
 				if ( is_array( $text ) ) {
@@ -939,7 +939,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$rows = ( ! empty( $args['attributes']['rows'] ) ) ? absint( $args['attributes']['rows'] ) : 5;
 			$cols = ( ! empty( $args['attributes']['cols'] ) ) ? absint( $args['attributes']['cols'] ) : 60;
 
-			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="' . esc_attr( $rows ) . '" cols="' . esc_attr( $cols ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>' . esc_html( $args['value'] ) . '</textarea>';
+			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="' . esc_attr( $rows ) . '" cols="' . esc_attr( $cols ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '>' . esc_html( $args['value'] ) . '</textarea>';
 
 			$this->generate_description( $args );
 		}

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -1057,6 +1057,8 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			echo sprintf( '<input type="text" name="%s" id="%s" value="%s" class="regular-text %s"> ', esc_attr( $args['name'] ), esc_attr( $args['id'] ), esc_html( $args['value'] ), esc_attr( $args['class'] ) );
 
 			echo sprintf( '<input type="button" class="button wpsf-browse" id="%s" value="%s" />', esc_attr( $button_id ), esc_html__( 'Browse', 'wpsf' ) );
+
+			$this->generate_description( $args );
 			?>
 			<script type='text/javascript'>
 				jQuery( document ).ready( function( $ ) {

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -936,8 +936,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 */
 		public function generate_textarea_field( $args ) {
 			$args['value'] = esc_html( esc_attr( $args['value'] ) );
+			$rows = ( ! empty( $args['attributes']['rows'] ) ) ? absint( $args['attributes']['rows'] ) : 5;
+			$cols = ( ! empty( $args['attributes']['cols'] ) ) ? absint( $args['attributes']['cols'] ) : 60;
 
-			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="5" cols="60" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>' . esc_html( $args['value'] ) . '</textarea>';
+			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="' . esc_attr( $rows ) . '" cols="' . esc_attr( $cols ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>' . esc_html( $args['value'] ) . '</textarea>';
 
 			$this->generate_description( $args );
 		}

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -78,6 +78,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			'class'        => '',
 			'subfields'    => array(),
 			'autocomplete' => '',
+			'attributes'   => array(),
 		);
 
 		/**
@@ -583,7 +584,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_text_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" />';
+			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			$this->generate_description( $args );
 		}
@@ -596,7 +597,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_hidden_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			echo '<input type="hidden" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '"  class="hidden-field ' . esc_attr( $args['class'] ) . '" />';
+			echo '<input type="hidden" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '"  class="hidden-field ' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 		}
 
 		/**
@@ -607,7 +608,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_number_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			echo '<input type="number" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" />';
+			echo '<input type="number" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			$this->generate_description( $args );
 		}
@@ -622,7 +623,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			$timepicker = ( ! empty( $args['timepicker'] ) ) ? htmlentities( wp_json_encode( $args['timepicker'] ) ) : null;
 
-			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" class="timepicker regular-text ' . esc_attr( $args['class'] ) . '" data-timepicker="' . esc_attr( $timepicker ) . '" />';
+			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" class="timepicker regular-text ' . esc_attr( $args['class'] ) . '" data-timepicker="' . esc_attr( $timepicker ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			$this->generate_description( $args );
 		}
@@ -637,7 +638,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			$datepicker = ( ! empty( $args['datepicker'] ) ) ? htmlentities( wp_json_encode( $args['datepicker'] ) ) : null;
 
-			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" class="datepicker regular-text ' . esc_attr( $args['class'] ) . '" data-datepicker="' . esc_attr( $datepicker ) . '" />';
+			echo '<input type="text" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" class="datepicker regular-text ' . esc_attr( $args['class'] ) . '" data-datepicker="' . esc_attr( $datepicker ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			$this->generate_description( $args );
 		}
@@ -890,7 +891,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$values = (array) $args['value'];
 			$values = array_map( 'strval', $values );
 
-			echo '<select ' . esc_html( $multiple ) . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '" >';
+			echo '<select ' . esc_html( $multiple ) . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			foreach ( $args['choices'] as $value => $text ) {
 				if ( is_array( $text ) ) {
@@ -920,7 +921,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_password_field( $args ) {
 			$args['value'] = esc_attr( stripslashes( $args['value'] ) );
 
-			echo '<input type="password" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" autocomplete="' . esc_attr( $args['autocomplete'] ) . '"/>';
+			echo '<input type="password" name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $args['value'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" class="regular-text ' . esc_attr( $args['class'] ) . '" autocomplete="' . esc_attr( $args['autocomplete'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>';
 
 			$this->generate_description( $args );
 		}
@@ -933,7 +934,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		public function generate_textarea_field( $args ) {
 			$args['value'] = esc_html( esc_attr( $args['value'] ) );
 
-			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="5" cols="60" class="' . esc_attr( $args['class'] ) . '">' . esc_html( $args['value'] ) . '</textarea>';
+			echo '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" rows="5" cols="60" class="' . esc_attr( $args['class'] ) . '" ' . $this->array_to_html_atts( $args['attributes'] ) . '/>' . esc_html( $args['value'] ) . '</textarea>';
 
 			$this->generate_description( $args );
 		}
@@ -1619,6 +1620,27 @@ endwhile;
 			update_option( $option_group . '_settings', $settings_data );
 
 			wp_send_json_success();
+		}
+
+		/**
+		 * Helper: Array to HTML Attributes
+		 */
+		public static function array_to_html_atts( $array = array() ) {
+			if ( ! is_array( $array ) || empty( $array ) ) {
+				return false;
+			}
+
+			$return = '';
+
+			foreach ( $array as $key => $value ) {
+				if ( '' === $value ) {
+					continue;
+				}
+
+				$return .= sprintf( '%s="%s" ', $key, esc_attr( $value ) );
+			}
+
+			return $return;
 		}
 	}
 }

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -702,7 +702,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$value     = (array) $args['value'];
 			$row_count = ( ! empty( $value ) ) ? count( $value ) : 1;
 
-			echo '<table class="widefat wpsf-group" cellspacing="0">';
+			echo '<table id="group-' . esc_attr( str_replace( '_', '-', $args['id'] ) ) . '" class="' . esc_attr( $args['class'] ) . ' widefat wpsf-group" cellspacing="0">';
 
 			echo '<tbody>';
 

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -1054,6 +1054,11 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			$args['value'] = esc_attr( $args['value'] );
 			$button_id     = sprintf( '%s_button', $args['id'] );
 
+			/**
+			 * Hook in to generate a file preview e.g. image thumbnail.
+			 */
+			do_action( 'wpsf_file_field_preview', $args['value'], $args );
+
 			echo sprintf( '<input type="text" name="%s" id="%s" value="%s" class="regular-text %s"> ', esc_attr( $args['name'] ), esc_attr( $args['id'] ), esc_html( $args['value'] ), esc_attr( $args['class'] ) );
 
 			echo sprintf( '<input type="button" class="button wpsf-browse" id="%s" value="%s" />', esc_attr( $button_id ), esc_html__( 'Browse', 'wpsf' ) );

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -716,6 +716,8 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 			echo '</table>';
 
+			$this->generate_description( $args );
+
 			printf(
 				'<script type="text/html" id="%s_template">%s</script>',
 				esc_attr( $args['id'] ),
@@ -1235,7 +1237,7 @@ endwhile;
 			if ( $description ) {
 				$descriptions[] = array(
 					'classes'     => $classes,
-					'value'       => $args['value'],
+					'value'       => ( is_array( $args['value'] ) ) ? serialize( $args['value'] ) : $args['value'],
 					'description' => $description,
 				);
 			}

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -79,6 +79,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 			'subfields'    => array(),
 			'autocomplete' => '',
 			'attributes'   => array(),
+			'custom_args'  => array(),
 		);
 
 		/**
@@ -1237,6 +1238,7 @@ endwhile;
 			if ( $description ) {
 				$descriptions[] = array(
 					'classes'     => $classes,
+					// Serialize group field data to prevent errors.
 					'value'       => ( is_array( $args['value'] ) ) ? serialize( $args['value'] ) : $args['value'],
 					'description' => $description,
 				);


### PR DESCRIPTION
- Expose WPSF methods for use elsewhere. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/a2608a3f26350112106de7e9a943e36e7dc89bcf))
- Ensure reindex_group logic fires for select fields. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/e28a4accf4bff590bb4e7d8b1a0c0a4fee188e97))
- Added support for custom attributes to some, but not all fields. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/39fc2f45adfc557b3edb227e7a25c43d38753827))
- Give group field table elements a unique ID for styling purposes. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/06086bb53154ec01e9f8d6cd7c4f77699d9f518a))
- Output desc field for groups, serialize group data to prevent PHP error. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/c900aaf71db5c31355e0f67da995f05f2ff03d13))
- Added support for custom_args param, can be useful in custom fields. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/5ad7b011567b8d3b969d6f5e0ab959672a13031f))
- Populate textarea rows/cols using new attributes param, falling back to defaults. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/e582dcdebc1dd8f2b33ae3e4558ebf2f2c71fd53))
- Output description for the file field. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/cda4a5d5bea40474fa5f236a176291594326b94d))
- Add action hook to generate file field previews. ([commit](https://github.com/iconicwp/WordPress-Settings-Framework/pull/117/commits/1069318071054723a0dcf74cf607e78d20c79ef9))