### PR TITLE
Fix the tab save button

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -1296,7 +1296,7 @@ endwhile;
 			 */
 			do_action( 'wpsf_before_settings_' . $this->option_group );
 			?>
-			<form action="options.php" method="post" novalidate enctype="multipart/form-data">
+			<form id="wpsf-form" action="options.php" method="post" novalidate enctype="multipart/form-data">
 				<?php
 				/**
 				 * Hook: execute callback before the settings fields for a given group.
@@ -1472,7 +1472,7 @@ endwhile;
 				}
 				?>
 				<li class="wpsf-nav__item wpsf-nav__item--last">
-					<input type="submit" class="button-primary wpsf-button-submit" value="<?php esc_attr_e( 'Save Changes' ); ?>">
+					<input form="wpsf-form" type="submit" class="button-primary wpsf-button-submit" value="<?php esc_attr_e( 'Save Changes' ); ?>">
 				</li>
 			</ul>
 


### PR DESCRIPTION
Fix the save changes button that appears in the tab layout.

As it's outside the form element if other forms are active on the page (such as in the admin notices) it will fail to submit the wpsf form.